### PR TITLE
Add TesseractOCR test and document Ubuntu dependencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,3 +24,4 @@
 - Requires Tesseract binaries and language data (`TESSDATA_PREFIX`).
 - Fully CPU based; no GPU dependencies.
 - Build and tests must use `~/.dotnet/dotnet` from `dotnet-install.sh`.
+- On Ubuntu 24.04 obtain Tesseract 5.x and Leptonica 1.85 binaries (e.g. from the [jitesoft/docker-tesseract-ocr](https://github.com/jitesoft/docker-tesseract-ocr/pkgs/container/tesseract/) packages). The `TesseractOCR` wrapper looks for `libtesseract55.dll.so` and `libleptonica-1.85.0.dll.so`; creating symlinks to system libraries is sufficient.

--- a/README.md
+++ b/README.md
@@ -40,12 +40,27 @@ All build and test commands must use the locally installed `dotnet`:
 ~/.dotnet/dotnet test
 ```
 
+## Ubuntu 24.04 dependencies
+
+The `TesseractOCR` package requires native **Tesseract** and **Leptonica** libraries. Prebuilt `.deb` archives for Ubuntu 24.04 are published with the [jitesoft/docker-tesseract-ocr](https://github.com/jitesoft/docker-tesseract-ocr/pkgs/container/tesseract/) container. Install them with `dpkg` or `apt`:
+
+```bash
+curl -LO https://github.com/jitesoft/docker-tesseract-ocr/pkgs/container/tesseract/latest/download?filename=libleptonica_1.85.0-1_amd64.deb
+curl -LO https://github.com/jitesoft/docker-tesseract-ocr/pkgs/container/tesseract/latest/download?filename=libtesseract_5.4.1-1_amd64.deb
+sudo apt install ./libleptonica_1.85.0-1_amd64.deb ./libtesseract_5.4.1-1_amd64.deb
+
+# provide friendly names expected by TesseractOCR
+sudo ln -s /usr/lib/x86_64-linux-gnu/liblept.so.5 /usr/lib/x86_64-linux-gnu/libleptonica-1.85.0.dll.so
+sudo ln -s /usr/lib/x86_64-linux-gnu/libtesseract.so.5 /usr/lib/x86_64-linux-gnu/libtesseract55.dll.so
+sudo ln -s /usr/lib/x86_64-linux-gnu/libdl.so.2 /usr/lib/x86_64-linux-gnu/libdl.so
+```
+
 ## Usage
 
 ```csharp
 var options = new MarkItDownOptions
 {
-    OcrDataPath = "/usr/share/tesseract-ocr/4.00/tessdata",
+    OcrDataPath = "/usr/share/tesseract-ocr/5/tessdata",
     OcrLanguages = "eng",
     PdfRasterDpi = 300
 };

--- a/tests/MarkItDownNet.Tests/MarkItDownNet.Tests.csproj
+++ b/tests/MarkItDownNet.Tests/MarkItDownNet.Tests.csproj
@@ -14,6 +14,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="TesseractOCR" Version="5.5.1" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.7" />
+    <PackageReference Include="SixLabors.Fonts" Version="2.1.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MarkItDownNet.Tests/TesseractOcrTests.cs
+++ b/tests/MarkItDownNet.Tests/TesseractOcrTests.cs
@@ -1,0 +1,48 @@
+using System;
+using System.IO;
+using SixLabors.Fonts;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Drawing.Processing;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+using TesseractOCR;
+using TesseractOCR.Enums;
+
+namespace MarkItDownNet.Tests;
+
+public class TesseractOcrTests
+{
+    [Fact]
+    public void Can_extract_text_from_simple_image()
+    {
+        var libPath = Path.Combine(AppContext.BaseDirectory, "ocrlibs");
+        Directory.CreateDirectory(Path.Combine(libPath, "x64"));
+        var leptLink = Path.Combine(libPath, "x64", "libleptonica-1.85.0.dll.so");
+        var tessLink = Path.Combine(libPath, "x64", "libtesseract55.dll.so");
+        var dlLink = Path.Combine(libPath, "x64", "libdl.so");
+        File.Delete(leptLink);
+        File.Delete(tessLink);
+        File.Delete(dlLink);
+        File.CreateSymbolicLink(leptLink, "/usr/lib/x86_64-linux-gnu/liblept.so.5");
+        File.CreateSymbolicLink(tessLink, "/usr/lib/x86_64-linux-gnu/libtesseract.so.5");
+        File.CreateSymbolicLink(dlLink, "/usr/lib/x86_64-linux-gnu/libdl.so.2");
+        TesseractOCR.InteropDotNet.LibraryLoader.Instance.CustomSearchPath = libPath;
+
+        using var image = new Image<Rgba32>(120, 40);
+        image.Mutate(ctx =>
+        {
+            ctx.Fill(Color.White);
+            Font font = SystemFonts.CreateFont("DejaVu Sans", 20);
+            ctx.DrawText("hi", font, Color.Black, new PointF(10, 5));
+        });
+
+        var temp = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".png");
+        image.Save(temp);
+
+        using var engine = new Engine("/usr/share/tesseract-ocr/5/tessdata", Language.English, EngineMode.Default);
+        using var pix = TesseractOCR.Pix.Image.LoadFromFile(temp);
+        using var page = engine.Process(pix);
+
+        Assert.Contains("hi", page.Text.ToLowerInvariant());
+    }
+}


### PR DESCRIPTION
## Summary
- document Ubuntu 24.04 Tesseract/Leptonica packages and required symlinks
- add TesseractOCR-based OCR test with ImageSharp-generated image

## Testing
- `~/.dotnet/dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689b8e30ece08325a7a833a240a7cdcc