### PR TITLE
Add Leptonica interop tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,21 @@ sudo ln -s /usr/lib/x86_64-linux-gnu/libtesseract.so.5 /usr/lib/x86_64-linux-gnu
 sudo ln -s /usr/lib/x86_64-linux-gnu/libdl.so.2 /usr/lib/x86_64-linux-gnu/libdl.so
 ```
 
+### Leptonica tests
+
+The `tests/MarkItDownNet.Tests/LeptonicaTests.cs` file contains two simple unit tests that call the native Leptonica API via `DllImport`. They create a `PIX` image and round-trip a pixel value to confirm the library is wired up correctly:
+
+```csharp
+[DllImport("libleptonica-1.85.0.dll.so", CallingConvention = CallingConvention.Cdecl)]
+static extern IntPtr pixCreate(int width, int height, int depth);
+```
+
+Ensure the `libleptonica-1.85.0.dll.so` symlink above exists before running the suite:
+
+```bash
+~/.dotnet/dotnet test
+```
+
 ## Usage
 
 ```csharp

--- a/tests/MarkItDownNet.Tests/LeptonicaTests.cs
+++ b/tests/MarkItDownNet.Tests/LeptonicaTests.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace MarkItDownNet.Tests;
+
+public class LeptonicaTests
+{
+    private const string LeptonicaDll = "libleptonica-1.85.0.dll.so";
+
+    [DllImport(LeptonicaDll, CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr pixCreate(int width, int height, int depth);
+
+    [DllImport(LeptonicaDll, CallingConvention = CallingConvention.Cdecl)]
+    private static extern int pixGetWidth(IntPtr pix);
+
+    [DllImport(LeptonicaDll, CallingConvention = CallingConvention.Cdecl)]
+    private static extern int pixGetHeight(IntPtr pix);
+
+    [DllImport(LeptonicaDll, CallingConvention = CallingConvention.Cdecl)]
+    private static extern int pixGetDepth(IntPtr pix);
+
+    [DllImport(LeptonicaDll, CallingConvention = CallingConvention.Cdecl)]
+    private static extern int pixSetPixel(IntPtr pix, int x, int y, uint value);
+
+    [DllImport(LeptonicaDll, CallingConvention = CallingConvention.Cdecl)]
+    private static extern int pixGetPixel(IntPtr pix, int x, int y, out uint value);
+
+    [DllImport(LeptonicaDll, CallingConvention = CallingConvention.Cdecl)]
+    private static extern void pixDestroy(ref IntPtr pix);
+
+    [Fact]
+    public void PixCreate_ShouldReturnCorrectDimensions()
+    {
+        IntPtr pix = pixCreate(100, 200, 8);
+        try
+        {
+            Assert.NotEqual(IntPtr.Zero, pix);
+            Assert.Equal(100, pixGetWidth(pix));
+            Assert.Equal(200, pixGetHeight(pix));
+            Assert.Equal(8, pixGetDepth(pix));
+        }
+        finally
+        {
+            pixDestroy(ref pix);
+        }
+    }
+
+    [Fact]
+    public void PixSetPixel_ShouldRoundTripValue()
+    {
+        IntPtr pix = pixCreate(1, 1, 8);
+        try
+        {
+            uint expected = 123;
+            Assert.Equal(0, pixSetPixel(pix, 0, 0, expected));
+            uint actual;
+            Assert.Equal(0, pixGetPixel(pix, 0, 0, out actual));
+            Assert.Equal(expected, actual);
+        }
+        finally
+        {
+            pixDestroy(ref pix);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests calling Leptonica via DllImport to verify basic pix operations
- document how to install Leptonica and run the tests on Ubuntu 24.04

## Testing
- `~/.dotnet/dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689ba8845ce08325b52cf87890d2e473