### PR TITLE
Document Tesseract/Leptonica setup and enable OCR tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,11 +25,20 @@
 - Requires Tesseract binaries and language data (`TESSDATA_PREFIX`).
 - Fully CPU based; no GPU dependencies.
 - Build and tests must use `~/.dotnet/dotnet` from `dotnet-install.sh`.
-- On Ubuntu 24.04 install Tesseract 5.x and the [`libleptonica-dev_1.82.0-3build4` package](https://ubuntu.pkgs.org/24.04/ubuntu-universe-amd64/libleptonica-dev_1.82.0-3build4_amd64.deb.html). The `TesseractOCR` wrapper expects `libtesseract55.dll.so` and `libleptonica-1.85.0.dll.so`; create symlinks to the system libraries:
+- The `TesseractOCR` 5.5.1 wrapper is built for **Tesseract 5.x** and needs **Leptonica ≥ 1.74**.
+- On Ubuntu 24.04 the `tesseract-ocr` (5.3.4 at time of writing) and `libleptonica-dev` (1.82.0) packages satisfy these requirements.
+- The wrapper looks for `libtesseract55.dll.so` and `libleptonica-1.85.0.dll.so`; provide them as symlinks to the system libraries:
 
 ```
+sudo apt-get update
 sudo apt-get install -y tesseract-ocr libleptonica-dev
-sudo ln -s /usr/lib/x86_64-linux-gnu/liblept.so.5 /usr/lib/x86_64-linux-gnu/libleptonica-1.85.0.dll.so
-sudo ln -s /usr/lib/x86_64-linux-gnu/libtesseract.so.5 /usr/lib/x86_64-linux-gnu/libtesseract55.dll.so
-sudo ln -s /usr/lib/x86_64-linux-gnu/libdl.so.2 /usr/lib/x86_64-linux-gnu/libdl.so
+sudo ln -sf /usr/lib/x86_64-linux-gnu/liblept.so.5 /usr/lib/x86_64-linux-gnu/libleptonica-1.85.0.dll.so
+sudo ln -sf /usr/lib/x86_64-linux-gnu/libtesseract.so.5 /usr/lib/x86_64-linux-gnu/libtesseract55.dll.so
+sudo ln -sf /usr/lib/x86_64-linux-gnu/libdl.so.2 /usr/lib/x86_64-linux-gnu/libdl.so
+```
+
+- Verify the installation:
+
+```
+tesseract --version  # should report leptonica 1.74+ and tesseract 5.x
 ```

--- a/README.md
+++ b/README.md
@@ -42,28 +42,33 @@ All build and test commands must use the locally installed `dotnet`:
 
 ## Ubuntu 24.04 dependencies
 
-The `TesseractOCR` package requires native **Tesseract** and **Leptonica** libraries. On Ubuntu 24.04 these are available via the standard packages, e.g. the [`libleptonica-dev_1.82.0-3build4` package](https://ubuntu.pkgs.org/24.04/ubuntu-universe-amd64/libleptonica-dev_1.82.0-3build4_amd64.deb.html):
+`TesseractOCR` 5.5.1 relies on native **Tesseract 5.x** and **Leptonica ≥ 1.74**. Ubuntu 24.04 packages provide suitable versions (`tesseract-ocr` 5.3.4 and `libleptonica-dev` 1.82.0):
 
 ```bash
 sudo apt-get update
 sudo apt-get install -y tesseract-ocr libleptonica-dev
 
 # provide friendly names expected by TesseractOCR
-sudo ln -s /usr/lib/x86_64-linux-gnu/liblept.so.5 /usr/lib/x86_64-linux-gnu/libleptonica-1.85.0.dll.so
-sudo ln -s /usr/lib/x86_64-linux-gnu/libtesseract.so.5 /usr/lib/x86_64-linux-gnu/libtesseract55.dll.so
-sudo ln -s /usr/lib/x86_64-linux-gnu/libdl.so.2 /usr/lib/x86_64-linux-gnu/libdl.so
+sudo ln -sf /usr/lib/x86_64-linux-gnu/liblept.so.5 /usr/lib/x86_64-linux-gnu/libleptonica-1.85.0.dll.so
+sudo ln -sf /usr/lib/x86_64-linux-gnu/libtesseract.so.5 /usr/lib/x86_64-linux-gnu/libtesseract55.dll.so
+sudo ln -sf /usr/lib/x86_64-linux-gnu/libdl.so.2 /usr/lib/x86_64-linux-gnu/libdl.so
+
+# check versions
+tesseract --version
 ```
 
-### Leptonica tests
+### Leptonica and Tesseract tests
 
-The `tests/MarkItDownNet.Tests/LeptonicaTests.cs` file contains two simple unit tests that call the native Leptonica API via `DllImport`. They create a `PIX` image and round-trip a pixel value to confirm the library is wired up correctly:
+`tests/MarkItDownNet.Tests/LeptonicaTests.cs` exercises the native Leptonica API via `DllImport`, creating a `PIX` image and round-tripping a pixel value.
+
+`tests/MarkItDownNet.Tests/TesseractOcrTests.cs` generates a small image containing the text "hi" and verifies that the Tesseract engine extracts the text correctly.
 
 ```csharp
 [DllImport("libleptonica-1.85.0.dll.so", CallingConvention = CallingConvention.Cdecl)]
 static extern IntPtr pixCreate(int width, int height, int depth);
 ```
 
-Ensure the `libleptonica-1.85.0.dll.so` symlink above exists before running the suite:
+Ensure the symlinks above exist before running the suite:
 
 ```bash
 ~/.dotnet/dotnet test

--- a/tests/MarkItDownNet.Tests/TesseractOcrTests.cs
+++ b/tests/MarkItDownNet.Tests/TesseractOcrTests.cs
@@ -9,31 +9,13 @@ namespace MarkItDownNet.Tests;
 
 public class TesseractOcrTests
 {
-    [Fact(Skip = "Requires native Tesseract libraries")]
+    [Fact]
     public void Can_extract_text_from_simple_image()
     {
-        var libPath = Path.Combine(AppContext.BaseDirectory, "ocrlibs");
-
-        var archPath = Path.Combine(libPath, "x64");
-        Directory.CreateDirectory(archPath);
-        var lept1 = Path.Combine(archPath, "libleptonica-1.85.0.dll.so");
-        var lept2 = Path.Combine(archPath, "libleptonica-1.82.0.so");
-        var lept3 = Path.Combine(archPath, "libleptonica-1.82.0.dll.so");
-        var tess = Path.Combine(archPath, "libtesseract55.dll.so");
-        var dl = Path.Combine(archPath, "libdl.so");
-        foreach (var p in new[]{lept1, lept2, lept3, tess, dl}) File.Delete(p);
-        File.CreateSymbolicLink(lept1, "/usr/lib/x86_64-linux-gnu/liblept.so.5");
-        File.CreateSymbolicLink(lept2, "/usr/lib/x86_64-linux-gnu/liblept.so.5");
-        File.CreateSymbolicLink(lept3, "/usr/lib/x86_64-linux-gnu/liblept.so.5");
-        File.CreateSymbolicLink(tess, "/usr/lib/x86_64-linux-gnu/libtesseract.so.5");
-        File.CreateSymbolicLink(dl, "/usr/lib/x86_64-linux-gnu/libdl.so.2");
-        foreach (var name in new[]{"libleptonica-1.85.0.dll.so","libleptonica-1.82.0.so","libleptonica-1.82.0.dll.so","libtesseract55.dll.so","libdl.so"})
-        {
-            var rootLink = Path.Combine(libPath, name);
-            File.Delete(rootLink);
-            File.CreateSymbolicLink(rootLink, Path.Combine(archPath, name));
-        }
-        LibraryLoader.Instance.CustomSearchPath = libPath;
+        // Ensure the loader searches the system library path where the
+        // `libtesseract55.dll.so` and `libleptonica-1.85.0.dll.so` symlinks
+        // have been created.
+        LibraryLoader.Instance.CustomSearchPath = "/usr/lib/x86_64-linux-gnu";
 
         using var surface = SKSurface.Create(new SKImageInfo(120, 40));
         var canvas = surface.Canvas;
@@ -50,14 +32,11 @@ public class TesseractOcrTests
             data.SaveTo(fs);
         }
 
-        try {
         using var engine = new Engine("/usr/share/tesseract-ocr/5/tessdata", Language.English, EngineMode.Default);
         using var pix = TesseractOCR.Pix.Image.LoadFromFile(temp);
         using var page = engine.Process(pix);
 
         Assert.Contains("hi", page.Text.ToLowerInvariant());
-        } catch (Exception) {
-        return;
-        }
     }
 }
+


### PR DESCRIPTION
## Summary
- detail Ubuntu 24.04 steps to install Tesseract 5.x and Leptonica with required symlinks
- clarify Tesseract/Leptonica requirements in documentation
- enable OCR tests verifying Leptonica API calls and simple Tesseract text extraction

## Testing
- `~/.dotnet/dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689bb1f84ef883259eb146132fed2159