### PR TITLE
MD parity bench: markitdown vs markitdownnet (baseline=markitdown)

### DIFF
--- a/artifacts/mdbench/bench-md.html
+++ b/artifacts/mdbench/bench-md.html
@@ -1,0 +1,30 @@
+<h1>MD Parity Report</h1>
+<h2>Run config</h2>
+<pre>{"os":"Ubuntu 24.04.2 LTS","dotnet":"9.0.0","python":"Python 3.12.10","timings_unit":"ms"}</pre>
+<h2>Text metrics</h2>
+<table><tr><th>scope</th><th>CER</th><th>Token-F1</th><th>Line-F1</th><th>n_files</th></tr>
+<tr><td>global</td><td>0.000</td><td>1.000</td><td>1.000</td><td>24</td></tr>
+<tr><td>FUNSD</td><td>0.000</td><td>1.000</td><td>1.000</td><td>4</td></tr>
+<tr><td>ICDAR</td><td>0.000</td><td>1.000</td><td>1.000</td><td>4</td></tr>
+<tr><td>SROIE2019</td><td>0.000</td><td>1.000</td><td>1.000</td><td>4</td></tr>
+<tr><td>PUBTABLES</td><td>0.000</td><td>1.000</td><td>1.000</td><td>8</td></tr>
+<tr><td>MARMOT</td><td>0.000</td><td>1.000</td><td>1.000</td><td>4</td></tr>
+</table>
+<h2>Structure metrics</h2>
+<table><tr><th>scope</th><th>H1</th><th>H2</th><th>H3</th><th>list_items</th><th>max_list_depth</th><th>tables_count</th><th>pipes_lines_avg</th></tr>
+<tr><td>global</td><td>16</td><td>7</td><td>0</td><td>4</td><td>1</td><td>31</td><td>5.8</td></tr>
+<tr><td>FUNSD</td><td>5</td><td>2</td><td>0</td><td>0</td><td>0</td><td>5</td><td>1.2</td></tr>
+<tr><td>ICDAR</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>21</td><td>30.8</td></tr>
+<tr><td>SROIE2019</td><td>11</td><td>5</td><td>0</td><td>1</td><td>1</td><td>1</td><td>0.2</td></tr>
+<tr><td>PUBTABLES</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>1</td><td>0.1</td></tr>
+<tr><td>MARMOT</td><td>0</td><td>0</td><td>0</td><td>3</td><td>1</td><td>3</td><td>2.0</td></tr>
+</table>
+<h2>Sample diffs (worst 3 / best 3)</h2>
+<ol>
+<li>worst FUNSD/82250337_0338.md <a href='dataset/validation/_md/markitdown/FUNSD/82250337_0338.md'>ref</a> <a href='dataset/validation/_md/markitdownnet/FUNSD/82250337_0338.md'>hyp</a></li>
+<li>worst FUNSD/82092117.md <a href='dataset/validation/_md/markitdown/FUNSD/82092117.md'>ref</a> <a href='dataset/validation/_md/markitdownnet/FUNSD/82092117.md'>hyp</a></li>
+<li>worst FUNSD/82251504.md <a href='dataset/validation/_md/markitdown/FUNSD/82251504.md'>ref</a> <a href='dataset/validation/_md/markitdownnet/FUNSD/82251504.md'>hyp</a></li>
+<li>best FUNSD/82250337_0338.md <a href='dataset/validation/_md/markitdown/FUNSD/82250337_0338.md'>ref</a> <a href='dataset/validation/_md/markitdownnet/FUNSD/82250337_0338.md'>hyp</a></li>
+<li>best FUNSD/82092117.md <a href='dataset/validation/_md/markitdown/FUNSD/82092117.md'>ref</a> <a href='dataset/validation/_md/markitdownnet/FUNSD/82092117.md'>hyp</a></li>
+<li>best FUNSD/82251504.md <a href='dataset/validation/_md/markitdown/FUNSD/82251504.md'>ref</a> <a href='dataset/validation/_md/markitdownnet/FUNSD/82251504.md'>hyp</a></li>
+</ol>

--- a/artifacts/mdbench/bench-md.json
+++ b/artifacts/mdbench/bench-md.json
@@ -1,0 +1,1491 @@
+{
+  "task": "MD-PARITY",
+  "run_config": {
+    "os": "Ubuntu 24.04.2 LTS",
+    "dotnet": "9.0.0",
+    "python": "Python 3.12.10",
+    "timings_unit": "ms"
+  },
+  "files": [
+    {
+      "dataset": "FUNSD",
+      "paths": {
+        "ref_md": "dataset/validation/_md/markitdown/FUNSD/82250337_0338.md",
+        "hyp_md": "dataset/validation/_md/markitdownnet/FUNSD/82250337_0338.md",
+        "src_txt": "dataset/validation/_ocr/pytesseract-cli/FUNSD/82250337_0338.mdready.txt"
+      },
+      "metrics": {
+        "text": {
+          "cer_char": 0,
+          "token_precision": 1,
+          "token_recall": 1,
+          "token_f1": 1,
+          "ref_tokens": 207,
+          "hyp_tokens": 207,
+          "token_matches": 207,
+          "ref_chars": 1343,
+          "char_distance": 0
+        },
+        "lines": {
+          "line_count_ref": 50,
+          "line_count_hyp": 50,
+          "line_f1": 1,
+          "line_matches": 50
+        },
+        "structure": {
+          "ref_struct": {
+            "h1": 2,
+            "h2": 1,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 0,
+            "pipes_lines_count": 0,
+            "median_pipes_per_line": 0,
+            "max_pipes_per_line": 0
+          },
+          "hyp_struct": {
+            "h1": 2,
+            "h2": 1,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 0,
+            "pipes_lines_count": 0,
+            "median_pipes_per_line": 0,
+            "max_pipes_per_line": 0
+          }
+        }
+      },
+      "timing_ms": 79
+    },
+    {
+      "dataset": "FUNSD",
+      "paths": {
+        "ref_md": "dataset/validation/_md/markitdown/FUNSD/82092117.md",
+        "hyp_md": "dataset/validation/_md/markitdownnet/FUNSD/82092117.md",
+        "src_txt": "dataset/validation/_ocr/pytesseract-cli/FUNSD/82092117.mdready.txt"
+      },
+      "metrics": {
+        "text": {
+          "cer_char": 0,
+          "token_precision": 1,
+          "token_recall": 1,
+          "token_f1": 1,
+          "ref_tokens": 201,
+          "hyp_tokens": 201,
+          "token_matches": 201,
+          "ref_chars": 1184,
+          "char_distance": 0
+        },
+        "lines": {
+          "line_count_ref": 32,
+          "line_count_hyp": 32,
+          "line_f1": 1,
+          "line_matches": 32
+        },
+        "structure": {
+          "ref_struct": {
+            "h1": 2,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 3,
+            "pipes_lines_count": 3,
+            "median_pipes_per_line": 1,
+            "max_pipes_per_line": 1
+          },
+          "hyp_struct": {
+            "h1": 2,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 3,
+            "pipes_lines_count": 3,
+            "median_pipes_per_line": 1,
+            "max_pipes_per_line": 1
+          }
+        }
+      },
+      "timing_ms": 49
+    },
+    {
+      "dataset": "FUNSD",
+      "paths": {
+        "ref_md": "dataset/validation/_md/markitdown/FUNSD/82251504.md",
+        "hyp_md": "dataset/validation/_md/markitdownnet/FUNSD/82251504.md",
+        "src_txt": "dataset/validation/_ocr/pytesseract-cli/FUNSD/82251504.mdready.txt"
+      },
+      "metrics": {
+        "text": {
+          "cer_char": 0,
+          "token_precision": 1,
+          "token_recall": 1,
+          "token_f1": 1,
+          "ref_tokens": 128,
+          "hyp_tokens": 128,
+          "token_matches": 128,
+          "ref_chars": 803,
+          "char_distance": 0
+        },
+        "lines": {
+          "line_count_ref": 35,
+          "line_count_hyp": 35,
+          "line_f1": 1,
+          "line_matches": 35
+        },
+        "structure": {
+          "ref_struct": {
+            "h1": 1,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 0,
+            "pipes_lines_count": 0,
+            "median_pipes_per_line": 0,
+            "max_pipes_per_line": 0
+          },
+          "hyp_struct": {
+            "h1": 1,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 0,
+            "pipes_lines_count": 0,
+            "median_pipes_per_line": 0,
+            "max_pipes_per_line": 0
+          }
+        }
+      },
+      "timing_ms": 22
+    },
+    {
+      "dataset": "FUNSD",
+      "paths": {
+        "ref_md": "dataset/validation/_md/markitdown/FUNSD/82200067_0069.md",
+        "hyp_md": "dataset/validation/_md/markitdownnet/FUNSD/82200067_0069.md",
+        "src_txt": "dataset/validation/_ocr/pytesseract-cli/FUNSD/82200067_0069.mdready.txt"
+      },
+      "metrics": {
+        "text": {
+          "cer_char": 0,
+          "token_precision": 1,
+          "token_recall": 1,
+          "token_f1": 1,
+          "ref_tokens": 124,
+          "hyp_tokens": 124,
+          "token_matches": 124,
+          "ref_chars": 617,
+          "char_distance": 0
+        },
+        "lines": {
+          "line_count_ref": 33,
+          "line_count_hyp": 33,
+          "line_f1": 1,
+          "line_matches": 33
+        },
+        "structure": {
+          "ref_struct": {
+            "h1": 0,
+            "h2": 1,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 2,
+            "pipes_lines_count": 2,
+            "median_pipes_per_line": 1,
+            "max_pipes_per_line": 1
+          },
+          "hyp_struct": {
+            "h1": 0,
+            "h2": 1,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 2,
+            "pipes_lines_count": 2,
+            "median_pipes_per_line": 1,
+            "max_pipes_per_line": 1
+          }
+        }
+      },
+      "timing_ms": 7
+    },
+    {
+      "dataset": "ICDAR",
+      "paths": {
+        "ref_md": "dataset/validation/_md/markitdown/ICDAR/cTDaR_t00016.md",
+        "hyp_md": "dataset/validation/_md/markitdownnet/ICDAR/cTDaR_t00016.md",
+        "src_txt": "dataset/validation/_ocr/pytesseract-cli/ICDAR/cTDaR_t00016.mdready.txt"
+      },
+      "metrics": {
+        "text": {
+          "cer_char": 0,
+          "token_precision": 1,
+          "token_recall": 1,
+          "token_f1": 1,
+          "ref_tokens": 579,
+          "hyp_tokens": 579,
+          "token_matches": 579,
+          "ref_chars": 2108,
+          "char_distance": 0
+        },
+        "lines": {
+          "line_count_ref": 44,
+          "line_count_hyp": 44,
+          "line_f1": 1,
+          "line_matches": 44
+        },
+        "structure": {
+          "ref_struct": {
+            "h1": 0,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 5,
+            "pipes_lines_count": 40,
+            "median_pipes_per_line": 3,
+            "max_pipes_per_line": 7
+          },
+          "hyp_struct": {
+            "h1": 0,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 5,
+            "pipes_lines_count": 40,
+            "median_pipes_per_line": 3,
+            "max_pipes_per_line": 7
+          }
+        }
+      },
+      "timing_ms": 154
+    },
+    {
+      "dataset": "ICDAR",
+      "paths": {
+        "ref_md": "dataset/validation/_md/markitdown/ICDAR/cTDaR_t00015.md",
+        "hyp_md": "dataset/validation/_md/markitdownnet/ICDAR/cTDaR_t00015.md",
+        "src_txt": "dataset/validation/_ocr/pytesseract-cli/ICDAR/cTDaR_t00015.mdready.txt"
+      },
+      "metrics": {
+        "text": {
+          "cer_char": 0,
+          "token_precision": 1,
+          "token_recall": 1,
+          "token_f1": 1,
+          "ref_tokens": 451,
+          "hyp_tokens": 451,
+          "token_matches": 451,
+          "ref_chars": 1894,
+          "char_distance": 0
+        },
+        "lines": {
+          "line_count_ref": 36,
+          "line_count_hyp": 36,
+          "line_f1": 1,
+          "line_matches": 36
+        },
+        "structure": {
+          "ref_struct": {
+            "h1": 0,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 4,
+            "pipes_lines_count": 29,
+            "median_pipes_per_line": 3,
+            "max_pipes_per_line": 10
+          },
+          "hyp_struct": {
+            "h1": 0,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 4,
+            "pipes_lines_count": 29,
+            "median_pipes_per_line": 3,
+            "max_pipes_per_line": 10
+          }
+        }
+      },
+      "timing_ms": 118
+    },
+    {
+      "dataset": "ICDAR",
+      "paths": {
+        "ref_md": "dataset/validation/_md/markitdown/ICDAR/cTDaR_t00014.md",
+        "hyp_md": "dataset/validation/_md/markitdownnet/ICDAR/cTDaR_t00014.md",
+        "src_txt": "dataset/validation/_ocr/pytesseract-cli/ICDAR/cTDaR_t00014.mdready.txt"
+      },
+      "metrics": {
+        "text": {
+          "cer_char": 0,
+          "token_precision": 1,
+          "token_recall": 1,
+          "token_f1": 1,
+          "ref_tokens": 392,
+          "hyp_tokens": 392,
+          "token_matches": 392,
+          "ref_chars": 1667,
+          "char_distance": 0
+        },
+        "lines": {
+          "line_count_ref": 38,
+          "line_count_hyp": 38,
+          "line_f1": 1,
+          "line_matches": 38
+        },
+        "structure": {
+          "ref_struct": {
+            "h1": 0,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 4,
+            "pipes_lines_count": 34,
+            "median_pipes_per_line": 3,
+            "max_pipes_per_line": 6
+          },
+          "hyp_struct": {
+            "h1": 0,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 4,
+            "pipes_lines_count": 34,
+            "median_pipes_per_line": 3,
+            "max_pipes_per_line": 6
+          }
+        }
+      },
+      "timing_ms": 84
+    },
+    {
+      "dataset": "ICDAR",
+      "paths": {
+        "ref_md": "dataset/validation/_md/markitdown/ICDAR/cTDaR_t00080.md",
+        "hyp_md": "dataset/validation/_md/markitdownnet/ICDAR/cTDaR_t00080.md",
+        "src_txt": "dataset/validation/_ocr/pytesseract-cli/ICDAR/cTDaR_t00080.mdready.txt"
+      },
+      "metrics": {
+        "text": {
+          "cer_char": 0,
+          "token_precision": 1,
+          "token_recall": 1,
+          "token_f1": 1,
+          "ref_tokens": 539,
+          "hyp_tokens": 539,
+          "token_matches": 539,
+          "ref_chars": 1798,
+          "char_distance": 0
+        },
+        "lines": {
+          "line_count_ref": 56,
+          "line_count_hyp": 56,
+          "line_f1": 1,
+          "line_matches": 56
+        },
+        "structure": {
+          "ref_struct": {
+            "h1": 0,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 8,
+            "pipes_lines_count": 20,
+            "median_pipes_per_line": 1,
+            "max_pipes_per_line": 3
+          },
+          "hyp_struct": {
+            "h1": 0,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 8,
+            "pipes_lines_count": 20,
+            "median_pipes_per_line": 1,
+            "max_pipes_per_line": 3
+          }
+        }
+      },
+      "timing_ms": 114
+    },
+    {
+      "dataset": "SROIE2019",
+      "paths": {
+        "ref_md": "dataset/validation/_md/markitdown/SROIE2019/X51005200931.md",
+        "hyp_md": "dataset/validation/_md/markitdownnet/SROIE2019/X51005200931.md",
+        "src_txt": "dataset/validation/_ocr/pytesseract-cli/SROIE2019/X51005200931.mdready.txt"
+      },
+      "metrics": {
+        "text": {
+          "cer_char": 0,
+          "token_precision": 1,
+          "token_recall": 1,
+          "token_f1": 1,
+          "ref_tokens": 168,
+          "hyp_tokens": 168,
+          "token_matches": 168,
+          "ref_chars": 894,
+          "char_distance": 0
+        },
+        "lines": {
+          "line_count_ref": 41,
+          "line_count_hyp": 41,
+          "line_f1": 1,
+          "line_matches": 41
+        },
+        "structure": {
+          "ref_struct": {
+            "h1": 5,
+            "h2": 1,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 0,
+            "pipes_lines_count": 0,
+            "median_pipes_per_line": 0,
+            "max_pipes_per_line": 0
+          },
+          "hyp_struct": {
+            "h1": 5,
+            "h2": 1,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 0,
+            "pipes_lines_count": 0,
+            "median_pipes_per_line": 0,
+            "max_pipes_per_line": 0
+          }
+        }
+      },
+      "timing_ms": 15
+    },
+    {
+      "dataset": "SROIE2019",
+      "paths": {
+        "ref_md": "dataset/validation/_md/markitdown/SROIE2019/X00016469670.md",
+        "hyp_md": "dataset/validation/_md/markitdownnet/SROIE2019/X00016469670.md",
+        "src_txt": "dataset/validation/_ocr/pytesseract-cli/SROIE2019/X00016469670.mdready.txt"
+      },
+      "metrics": {
+        "text": {
+          "cer_char": 0,
+          "token_precision": 1,
+          "token_recall": 1,
+          "token_f1": 1,
+          "ref_tokens": 110,
+          "hyp_tokens": 110,
+          "token_matches": 110,
+          "ref_chars": 652,
+          "char_distance": 0
+        },
+        "lines": {
+          "line_count_ref": 28,
+          "line_count_hyp": 28,
+          "line_f1": 1,
+          "line_matches": 28
+        },
+        "structure": {
+          "ref_struct": {
+            "h1": 1,
+            "h2": 2,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 0,
+            "pipes_lines_count": 0,
+            "median_pipes_per_line": 0,
+            "max_pipes_per_line": 0
+          },
+          "hyp_struct": {
+            "h1": 1,
+            "h2": 2,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 0,
+            "pipes_lines_count": 0,
+            "median_pipes_per_line": 0,
+            "max_pipes_per_line": 0
+          }
+        }
+      },
+      "timing_ms": 8
+    },
+    {
+      "dataset": "SROIE2019",
+      "paths": {
+        "ref_md": "dataset/validation/_md/markitdown/SROIE2019/X51005230605.md",
+        "hyp_md": "dataset/validation/_md/markitdownnet/SROIE2019/X51005230605.md",
+        "src_txt": "dataset/validation/_ocr/pytesseract-cli/SROIE2019/X51005230605.mdready.txt"
+      },
+      "metrics": {
+        "text": {
+          "cer_char": 0,
+          "token_precision": 1,
+          "token_recall": 1,
+          "token_f1": 1,
+          "ref_tokens": 92,
+          "hyp_tokens": 92,
+          "token_matches": 92,
+          "ref_chars": 503,
+          "char_distance": 0
+        },
+        "lines": {
+          "line_count_ref": 25,
+          "line_count_hyp": 25,
+          "line_f1": 1,
+          "line_matches": 25
+        },
+        "structure": {
+          "ref_struct": {
+            "h1": 3,
+            "h2": 1,
+            "h3": 0,
+            "list_items": 1,
+            "max_list_depth": 1,
+            "tables_count": 0,
+            "pipes_lines_count": 0,
+            "median_pipes_per_line": 0,
+            "max_pipes_per_line": 0
+          },
+          "hyp_struct": {
+            "h1": 3,
+            "h2": 1,
+            "h3": 0,
+            "list_items": 1,
+            "max_list_depth": 1,
+            "tables_count": 0,
+            "pipes_lines_count": 0,
+            "median_pipes_per_line": 0,
+            "max_pipes_per_line": 0
+          }
+        }
+      },
+      "timing_ms": 5
+    },
+    {
+      "dataset": "SROIE2019",
+      "paths": {
+        "ref_md": "dataset/validation/_md/markitdown/SROIE2019/X00016469671.md",
+        "hyp_md": "dataset/validation/_md/markitdownnet/SROIE2019/X00016469671.md",
+        "src_txt": "dataset/validation/_ocr/pytesseract-cli/SROIE2019/X00016469671.mdready.txt"
+      },
+      "metrics": {
+        "text": {
+          "cer_char": 0,
+          "token_precision": 1,
+          "token_recall": 1,
+          "token_f1": 1,
+          "ref_tokens": 99,
+          "hyp_tokens": 99,
+          "token_matches": 99,
+          "ref_chars": 594,
+          "char_distance": 0
+        },
+        "lines": {
+          "line_count_ref": 28,
+          "line_count_hyp": 28,
+          "line_f1": 1,
+          "line_matches": 28
+        },
+        "structure": {
+          "ref_struct": {
+            "h1": 2,
+            "h2": 1,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 1,
+            "pipes_lines_count": 1,
+            "median_pipes_per_line": 1,
+            "max_pipes_per_line": 1
+          },
+          "hyp_struct": {
+            "h1": 2,
+            "h2": 1,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 1,
+            "pipes_lines_count": 1,
+            "median_pipes_per_line": 1,
+            "max_pipes_per_line": 1
+          }
+        }
+      },
+      "timing_ms": 10
+    },
+    {
+      "dataset": "PUBTABLES",
+      "paths": {
+        "ref_md": "dataset/validation/_md/markitdown/PUBTABLES/PMC1064078_table_4.md",
+        "hyp_md": "dataset/validation/_md/markitdownnet/PUBTABLES/PMC1064078_table_4.md",
+        "src_txt": "dataset/validation/_ocr/pytesseract-cli/PUBTABLES/PMC1064078_table_4.mdready.txt"
+      },
+      "metrics": {
+        "text": {
+          "cer_char": 0,
+          "token_precision": 1,
+          "token_recall": 1,
+          "token_f1": 1,
+          "ref_tokens": 156,
+          "hyp_tokens": 156,
+          "token_matches": 156,
+          "ref_chars": 786,
+          "char_distance": 0
+        },
+        "lines": {
+          "line_count_ref": 21,
+          "line_count_hyp": 21,
+          "line_f1": 1,
+          "line_matches": 21
+        },
+        "structure": {
+          "ref_struct": {
+            "h1": 0,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 0,
+            "pipes_lines_count": 0,
+            "median_pipes_per_line": 0,
+            "max_pipes_per_line": 0
+          },
+          "hyp_struct": {
+            "h1": 0,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 0,
+            "pipes_lines_count": 0,
+            "median_pipes_per_line": 0,
+            "max_pipes_per_line": 0
+          }
+        }
+      },
+      "timing_ms": 11
+    },
+    {
+      "dataset": "PUBTABLES",
+      "paths": {
+        "ref_md": "dataset/validation/_md/markitdown/PUBTABLES/PMC1064078_table_3.md",
+        "hyp_md": "dataset/validation/_md/markitdownnet/PUBTABLES/PMC1064078_table_3.md",
+        "src_txt": "dataset/validation/_ocr/pytesseract-cli/PUBTABLES/PMC1064078_table_3.mdready.txt"
+      },
+      "metrics": {
+        "text": {
+          "cer_char": 0,
+          "token_precision": 1,
+          "token_recall": 1,
+          "token_f1": 1,
+          "ref_tokens": 69,
+          "hyp_tokens": 69,
+          "token_matches": 69,
+          "ref_chars": 294,
+          "char_distance": 0
+        },
+        "lines": {
+          "line_count_ref": 13,
+          "line_count_hyp": 13,
+          "line_f1": 1,
+          "line_matches": 13
+        },
+        "structure": {
+          "ref_struct": {
+            "h1": 0,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 0,
+            "pipes_lines_count": 0,
+            "median_pipes_per_line": 0,
+            "max_pipes_per_line": 0
+          },
+          "hyp_struct": {
+            "h1": 0,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 0,
+            "pipes_lines_count": 0,
+            "median_pipes_per_line": 0,
+            "max_pipes_per_line": 0
+          }
+        }
+      },
+      "timing_ms": 1
+    },
+    {
+      "dataset": "PUBTABLES",
+      "paths": {
+        "ref_md": "dataset/validation/_md/markitdown/PUBTABLES/PMC1064078_table_6.md",
+        "hyp_md": "dataset/validation/_md/markitdownnet/PUBTABLES/PMC1064078_table_6.md",
+        "src_txt": "dataset/validation/_ocr/pytesseract-cli/PUBTABLES/PMC1064078_table_6.mdready.txt"
+      },
+      "metrics": {
+        "text": {
+          "cer_char": 0,
+          "token_precision": 1,
+          "token_recall": 1,
+          "token_f1": 1,
+          "ref_tokens": 51,
+          "hyp_tokens": 51,
+          "token_matches": 51,
+          "ref_chars": 220,
+          "char_distance": 0
+        },
+        "lines": {
+          "line_count_ref": 7,
+          "line_count_hyp": 7,
+          "line_f1": 1,
+          "line_matches": 7
+        },
+        "structure": {
+          "ref_struct": {
+            "h1": 0,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 0,
+            "pipes_lines_count": 0,
+            "median_pipes_per_line": 0,
+            "max_pipes_per_line": 0
+          },
+          "hyp_struct": {
+            "h1": 0,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 0,
+            "pipes_lines_count": 0,
+            "median_pipes_per_line": 0,
+            "max_pipes_per_line": 0
+          }
+        }
+      },
+      "timing_ms": 1
+    },
+    {
+      "dataset": "PUBTABLES",
+      "paths": {
+        "ref_md": "dataset/validation/_md/markitdown/PUBTABLES/PMC1064082_table_0.md",
+        "hyp_md": "dataset/validation/_md/markitdownnet/PUBTABLES/PMC1064082_table_0.md",
+        "src_txt": "dataset/validation/_ocr/pytesseract-cli/PUBTABLES/PMC1064082_table_0.mdready.txt"
+      },
+      "metrics": {
+        "text": {
+          "cer_char": 0,
+          "token_precision": 1,
+          "token_recall": 1,
+          "token_f1": 1,
+          "ref_tokens": 13,
+          "hyp_tokens": 13,
+          "token_matches": 13,
+          "ref_chars": 71,
+          "char_distance": 0
+        },
+        "lines": {
+          "line_count_ref": 3,
+          "line_count_hyp": 3,
+          "line_f1": 1,
+          "line_matches": 3
+        },
+        "structure": {
+          "ref_struct": {
+            "h1": 0,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 0,
+            "pipes_lines_count": 0,
+            "median_pipes_per_line": 0,
+            "max_pipes_per_line": 0
+          },
+          "hyp_struct": {
+            "h1": 0,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 0,
+            "pipes_lines_count": 0,
+            "median_pipes_per_line": 0,
+            "max_pipes_per_line": 0
+          }
+        }
+      },
+      "timing_ms": 0
+    },
+    {
+      "dataset": "PUBTABLES",
+      "paths": {
+        "ref_md": "dataset/validation/_md/markitdown/PUBTABLES/PMC1064078_table_2.md",
+        "hyp_md": "dataset/validation/_md/markitdownnet/PUBTABLES/PMC1064078_table_2.md",
+        "src_txt": "dataset/validation/_ocr/pytesseract-cli/PUBTABLES/PMC1064078_table_2.mdready.txt"
+      },
+      "metrics": {
+        "text": {
+          "cer_char": 0,
+          "token_precision": 1,
+          "token_recall": 1,
+          "token_f1": 1,
+          "ref_tokens": 134,
+          "hyp_tokens": 134,
+          "token_matches": 134,
+          "ref_chars": 667,
+          "char_distance": 0
+        },
+        "lines": {
+          "line_count_ref": 19,
+          "line_count_hyp": 19,
+          "line_f1": 1,
+          "line_matches": 19
+        },
+        "structure": {
+          "ref_struct": {
+            "h1": 0,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 1,
+            "pipes_lines_count": 1,
+            "median_pipes_per_line": 1,
+            "max_pipes_per_line": 1
+          },
+          "hyp_struct": {
+            "h1": 0,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 1,
+            "pipes_lines_count": 1,
+            "median_pipes_per_line": 1,
+            "max_pipes_per_line": 1
+          }
+        }
+      },
+      "timing_ms": 8
+    },
+    {
+      "dataset": "PUBTABLES",
+      "paths": {
+        "ref_md": "dataset/validation/_md/markitdown/PUBTABLES/PMC1064078_table_0.md",
+        "hyp_md": "dataset/validation/_md/markitdownnet/PUBTABLES/PMC1064078_table_0.md",
+        "src_txt": "dataset/validation/_ocr/pytesseract-cli/PUBTABLES/PMC1064078_table_0.mdready.txt"
+      },
+      "metrics": {
+        "text": {
+          "cer_char": 0,
+          "token_precision": 1,
+          "token_recall": 1,
+          "token_f1": 1,
+          "ref_tokens": 109,
+          "hyp_tokens": 109,
+          "token_matches": 109,
+          "ref_chars": 618,
+          "char_distance": 0
+        },
+        "lines": {
+          "line_count_ref": 10,
+          "line_count_hyp": 10,
+          "line_f1": 1,
+          "line_matches": 10
+        },
+        "structure": {
+          "ref_struct": {
+            "h1": 0,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 0,
+            "pipes_lines_count": 0,
+            "median_pipes_per_line": 0,
+            "max_pipes_per_line": 0
+          },
+          "hyp_struct": {
+            "h1": 0,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 0,
+            "pipes_lines_count": 0,
+            "median_pipes_per_line": 0,
+            "max_pipes_per_line": 0
+          }
+        }
+      },
+      "timing_ms": 11
+    },
+    {
+      "dataset": "PUBTABLES",
+      "paths": {
+        "ref_md": "dataset/validation/_md/markitdown/PUBTABLES/PMC1064082_table_1.md",
+        "hyp_md": "dataset/validation/_md/markitdownnet/PUBTABLES/PMC1064082_table_1.md",
+        "src_txt": "dataset/validation/_ocr/pytesseract-cli/PUBTABLES/PMC1064082_table_1.mdready.txt"
+      },
+      "metrics": {
+        "text": {
+          "cer_char": 0,
+          "token_precision": 1,
+          "token_recall": 1,
+          "token_f1": 1,
+          "ref_tokens": 134,
+          "hyp_tokens": 134,
+          "token_matches": 134,
+          "ref_chars": 729,
+          "char_distance": 0
+        },
+        "lines": {
+          "line_count_ref": 26,
+          "line_count_hyp": 26,
+          "line_f1": 1,
+          "line_matches": 26
+        },
+        "structure": {
+          "ref_struct": {
+            "h1": 0,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 0,
+            "pipes_lines_count": 0,
+            "median_pipes_per_line": 0,
+            "max_pipes_per_line": 0
+          },
+          "hyp_struct": {
+            "h1": 0,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 0,
+            "pipes_lines_count": 0,
+            "median_pipes_per_line": 0,
+            "max_pipes_per_line": 0
+          }
+        }
+      },
+      "timing_ms": 10
+    },
+    {
+      "dataset": "PUBTABLES",
+      "paths": {
+        "ref_md": "dataset/validation/_md/markitdown/PUBTABLES/PMC1064078_table_5.md",
+        "hyp_md": "dataset/validation/_md/markitdownnet/PUBTABLES/PMC1064078_table_5.md",
+        "src_txt": "dataset/validation/_ocr/pytesseract-cli/PUBTABLES/PMC1064078_table_5.mdready.txt"
+      },
+      "metrics": {
+        "text": {
+          "cer_char": 0,
+          "token_precision": 1,
+          "token_recall": 1,
+          "token_f1": 1,
+          "ref_tokens": 162,
+          "hyp_tokens": 162,
+          "token_matches": 162,
+          "ref_chars": 758,
+          "char_distance": 0
+        },
+        "lines": {
+          "line_count_ref": 15,
+          "line_count_hyp": 15,
+          "line_f1": 1,
+          "line_matches": 15
+        },
+        "structure": {
+          "ref_struct": {
+            "h1": 0,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 0,
+            "pipes_lines_count": 0,
+            "median_pipes_per_line": 0,
+            "max_pipes_per_line": 0
+          },
+          "hyp_struct": {
+            "h1": 0,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 0,
+            "pipes_lines_count": 0,
+            "median_pipes_per_line": 0,
+            "max_pipes_per_line": 0
+          }
+        }
+      },
+      "timing_ms": 10
+    },
+    {
+      "dataset": "MARMOT",
+      "paths": {
+        "ref_md": "dataset/validation/_md/markitdown/MARMOT/10.1.1.1.2014_4.md",
+        "hyp_md": "dataset/validation/_md/markitdownnet/MARMOT/10.1.1.1.2014_4.md",
+        "src_txt": "dataset/validation/_ocr/pytesseract-cli/MARMOT/10.1.1.1.2014_4.mdready.txt"
+      },
+      "metrics": {
+        "text": {
+          "cer_char": 0,
+          "token_precision": 1,
+          "token_recall": 1,
+          "token_f1": 1,
+          "ref_tokens": 429,
+          "hyp_tokens": 429,
+          "token_matches": 429,
+          "ref_chars": 2336,
+          "char_distance": 0
+        },
+        "lines": {
+          "line_count_ref": 36,
+          "line_count_hyp": 36,
+          "line_f1": 1,
+          "line_matches": 36
+        },
+        "structure": {
+          "ref_struct": {
+            "h1": 0,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 1,
+            "max_list_depth": 1,
+            "tables_count": 2,
+            "pipes_lines_count": 7,
+            "median_pipes_per_line": 1,
+            "max_pipes_per_line": 1
+          },
+          "hyp_struct": {
+            "h1": 0,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 1,
+            "max_list_depth": 1,
+            "tables_count": 2,
+            "pipes_lines_count": 7,
+            "median_pipes_per_line": 1,
+            "max_pipes_per_line": 1
+          }
+        }
+      },
+      "timing_ms": 152
+    },
+    {
+      "dataset": "MARMOT",
+      "paths": {
+        "ref_md": "dataset/validation/_md/markitdown/MARMOT/10.1.1.1.2013_64.md",
+        "hyp_md": "dataset/validation/_md/markitdownnet/MARMOT/10.1.1.1.2013_64.md",
+        "src_txt": "dataset/validation/_ocr/pytesseract-cli/MARMOT/10.1.1.1.2013_64.mdready.txt"
+      },
+      "metrics": {
+        "text": {
+          "cer_char": 0,
+          "token_precision": 1,
+          "token_recall": 1,
+          "token_f1": 1,
+          "ref_tokens": 108,
+          "hyp_tokens": 108,
+          "token_matches": 108,
+          "ref_chars": 677,
+          "char_distance": 0
+        },
+        "lines": {
+          "line_count_ref": 21,
+          "line_count_hyp": 21,
+          "line_f1": 1,
+          "line_matches": 21
+        },
+        "structure": {
+          "ref_struct": {
+            "h1": 0,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 0,
+            "pipes_lines_count": 0,
+            "median_pipes_per_line": 0,
+            "max_pipes_per_line": 0
+          },
+          "hyp_struct": {
+            "h1": 0,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 0,
+            "pipes_lines_count": 0,
+            "median_pipes_per_line": 0,
+            "max_pipes_per_line": 0
+          }
+        }
+      },
+      "timing_ms": 8
+    },
+    {
+      "dataset": "MARMOT",
+      "paths": {
+        "ref_md": "dataset/validation/_md/markitdown/MARMOT/10.1.1.1.2006_3.md",
+        "hyp_md": "dataset/validation/_md/markitdownnet/MARMOT/10.1.1.1.2006_3.md",
+        "src_txt": "dataset/validation/_ocr/pytesseract-cli/MARMOT/10.1.1.1.2006_3.mdready.txt"
+      },
+      "metrics": {
+        "text": {
+          "cer_char": 0,
+          "token_precision": 1,
+          "token_recall": 1,
+          "token_f1": 1,
+          "ref_tokens": 812,
+          "hyp_tokens": 812,
+          "token_matches": 812,
+          "ref_chars": 4918,
+          "char_distance": 0
+        },
+        "lines": {
+          "line_count_ref": 101,
+          "line_count_hyp": 101,
+          "line_f1": 1,
+          "line_matches": 101
+        },
+        "structure": {
+          "ref_struct": {
+            "h1": 0,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 2,
+            "max_list_depth": 1,
+            "tables_count": 1,
+            "pipes_lines_count": 1,
+            "median_pipes_per_line": 1,
+            "max_pipes_per_line": 1
+          },
+          "hyp_struct": {
+            "h1": 0,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 2,
+            "max_list_depth": 1,
+            "tables_count": 1,
+            "pipes_lines_count": 1,
+            "median_pipes_per_line": 1,
+            "max_pipes_per_line": 1
+          }
+        }
+      },
+      "timing_ms": 677
+    },
+    {
+      "dataset": "MARMOT",
+      "paths": {
+        "ref_md": "dataset/validation/_md/markitdown/MARMOT/10.1.1.1.2013_63.md",
+        "hyp_md": "dataset/validation/_md/markitdownnet/MARMOT/10.1.1.1.2013_63.md",
+        "src_txt": "dataset/validation/_ocr/pytesseract-cli/MARMOT/10.1.1.1.2013_63.mdready.txt"
+      },
+      "metrics": {
+        "text": {
+          "cer_char": 0,
+          "token_precision": 1,
+          "token_recall": 1,
+          "token_f1": 1,
+          "ref_tokens": 253,
+          "hyp_tokens": 253,
+          "token_matches": 253,
+          "ref_chars": 1261,
+          "char_distance": 0
+        },
+        "lines": {
+          "line_count_ref": 38,
+          "line_count_hyp": 38,
+          "line_f1": 1,
+          "line_matches": 38
+        },
+        "structure": {
+          "ref_struct": {
+            "h1": 0,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 0,
+            "pipes_lines_count": 0,
+            "median_pipes_per_line": 0,
+            "max_pipes_per_line": 0
+          },
+          "hyp_struct": {
+            "h1": 0,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 0,
+            "pipes_lines_count": 0,
+            "median_pipes_per_line": 0,
+            "max_pipes_per_line": 0
+          }
+        }
+      },
+      "timing_ms": 58
+    }
+  ],
+  "aggregate": {
+    "by_dataset": {
+      "FUNSD": {
+        "n_files": 4,
+        "text": {
+          "cer_char": 0,
+          "token_precision": 1,
+          "token_recall": 1,
+          "token_f1": 1
+        },
+        "lines": {
+          "line_count_ref": 150,
+          "line_count_hyp": 150,
+          "line_f1": 1
+        },
+        "structure": {
+          "ref_struct": {
+            "h1": 5,
+            "h2": 2,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 5,
+            "pipes_lines_count": 5,
+            "median_pipes_per_line": 0.5,
+            "max_pipes_per_line": 1
+          },
+          "hyp_struct": {
+            "h1": 5,
+            "h2": 2,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 5,
+            "pipes_lines_count": 5,
+            "median_pipes_per_line": 0.5,
+            "max_pipes_per_line": 1
+          }
+        }
+      },
+      "ICDAR": {
+        "n_files": 4,
+        "text": {
+          "cer_char": 0,
+          "token_precision": 1,
+          "token_recall": 1,
+          "token_f1": 1
+        },
+        "lines": {
+          "line_count_ref": 174,
+          "line_count_hyp": 174,
+          "line_f1": 1
+        },
+        "structure": {
+          "ref_struct": {
+            "h1": 0,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 21,
+            "pipes_lines_count": 123,
+            "median_pipes_per_line": 2.5,
+            "max_pipes_per_line": 10
+          },
+          "hyp_struct": {
+            "h1": 0,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 21,
+            "pipes_lines_count": 123,
+            "median_pipes_per_line": 2.5,
+            "max_pipes_per_line": 10
+          }
+        }
+      },
+      "SROIE2019": {
+        "n_files": 4,
+        "text": {
+          "cer_char": 0,
+          "token_precision": 1,
+          "token_recall": 1,
+          "token_f1": 1
+        },
+        "lines": {
+          "line_count_ref": 122,
+          "line_count_hyp": 122,
+          "line_f1": 1
+        },
+        "structure": {
+          "ref_struct": {
+            "h1": 11,
+            "h2": 5,
+            "h3": 0,
+            "list_items": 1,
+            "max_list_depth": 1,
+            "tables_count": 1,
+            "pipes_lines_count": 1,
+            "median_pipes_per_line": 0.25,
+            "max_pipes_per_line": 1
+          },
+          "hyp_struct": {
+            "h1": 11,
+            "h2": 5,
+            "h3": 0,
+            "list_items": 1,
+            "max_list_depth": 1,
+            "tables_count": 1,
+            "pipes_lines_count": 1,
+            "median_pipes_per_line": 0.25,
+            "max_pipes_per_line": 1
+          }
+        }
+      },
+      "PUBTABLES": {
+        "n_files": 8,
+        "text": {
+          "cer_char": 0,
+          "token_precision": 1,
+          "token_recall": 1,
+          "token_f1": 1
+        },
+        "lines": {
+          "line_count_ref": 114,
+          "line_count_hyp": 114,
+          "line_f1": 1
+        },
+        "structure": {
+          "ref_struct": {
+            "h1": 0,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 1,
+            "pipes_lines_count": 1,
+            "median_pipes_per_line": 0.125,
+            "max_pipes_per_line": 1
+          },
+          "hyp_struct": {
+            "h1": 0,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 0,
+            "max_list_depth": 0,
+            "tables_count": 1,
+            "pipes_lines_count": 1,
+            "median_pipes_per_line": 0.125,
+            "max_pipes_per_line": 1
+          }
+        }
+      },
+      "MARMOT": {
+        "n_files": 4,
+        "text": {
+          "cer_char": 0,
+          "token_precision": 1,
+          "token_recall": 1,
+          "token_f1": 1
+        },
+        "lines": {
+          "line_count_ref": 196,
+          "line_count_hyp": 196,
+          "line_f1": 1
+        },
+        "structure": {
+          "ref_struct": {
+            "h1": 0,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 3,
+            "max_list_depth": 1,
+            "tables_count": 3,
+            "pipes_lines_count": 8,
+            "median_pipes_per_line": 0.5,
+            "max_pipes_per_line": 1
+          },
+          "hyp_struct": {
+            "h1": 0,
+            "h2": 0,
+            "h3": 0,
+            "list_items": 3,
+            "max_list_depth": 1,
+            "tables_count": 3,
+            "pipes_lines_count": 8,
+            "median_pipes_per_line": 0.5,
+            "max_pipes_per_line": 1
+          }
+        }
+      }
+    },
+    "global": {
+      "n_files": 24,
+      "text": {
+        "cer_char": 0,
+        "token_precision": 1,
+        "token_recall": 1,
+        "token_f1": 1
+      },
+      "lines": {
+        "line_count_ref": 756,
+        "line_count_hyp": 756,
+        "line_f1": 1
+      },
+      "structure": {
+        "ref_struct": {
+          "h1": 16,
+          "h2": 7,
+          "h3": 0,
+          "list_items": 4,
+          "max_list_depth": 1,
+          "tables_count": 31,
+          "pipes_lines_count": 138,
+          "median_pipes_per_line": 0.6666666666666666,
+          "max_pipes_per_line": 10
+        },
+        "hyp_struct": {
+          "h1": 16,
+          "h2": 7,
+          "h3": 0,
+          "list_items": 4,
+          "max_list_depth": 1,
+          "tables_count": 31,
+          "pipes_lines_count": 138,
+          "median_pipes_per_line": 0.6666666666666666,
+          "max_pipes_per_line": 10
+        }
+      }
+    }
+  }
+}

--- a/artifacts/mdbench/summary-md.md
+++ b/artifacts/mdbench/summary-md.md
@@ -1,0 +1,29 @@
+**PASS**
+## Text
+|scope|CER|Token-F1|Line-F1|n_files|
+|---|---|---|---|---|
+|global|0.000|1.000|1.000|24|
+|FUNSD|0.000|1.000|1.000|4|
+|ICDAR|0.000|1.000|1.000|4|
+|SROIE2019|0.000|1.000|1.000|4|
+|PUBTABLES|0.000|1.000|1.000|8|
+|MARMOT|0.000|1.000|1.000|4|
+## Structure
+|scope|H1|H2|H3|list_items|max_list_depth|tables_count|pipes_lines_avg|
+|---|---|---|---|---|---|---|---|
+|global|16|7|0|4|1|31|5.8|
+|FUNSD|5|2|0|0|0|5|1.2|
+|ICDAR|0|0|0|0|0|21|30.8|
+|SROIE2019|11|5|0|1|1|1|0.2|
+|PUBTABLES|0|0|0|0|0|1|0.1|
+|MARMOT|0|0|0|3|1|3|2.0|
+## Top-5 worst files
+|file|token_f1|
+|---|---|
+|FUNSD/82250337_0338.md|1.000|
+|FUNSD/82092117.md|1.000|
+|FUNSD/82251504.md|1.000|
+|FUNSD/82200067_0069.md|1.000|
+|ICDAR/cTDaR_t00016.md|1.000|
+## Run config
+{"os":"Ubuntu 24.04.2 LTS","dotnet":"9.0.0","python":"Python 3.12.10","timings_unit":"ms"}

--- a/dataset/validation/_md/markitdown/FUNSD/82092117.md
+++ b/dataset/validation/_md/markitdown/FUNSD/82092117.md
@@ -1,0 +1,32 @@
+y
+ATT, GEN. ADMIN, OFFICE Fax:614~466-508?              Dec 1098 17646 POL
+SAA) Attorney General
+C oe. =ae#7 Getty D. Montgomery
+# CONFIDENTIAL FACSIMILE
+‘TRANSMISSION COVER SHEET
+FAX NO, (614) 466-5087
+‘TO: _ George Baroody
+FAX NUMBER:    (336) 335-7392          PHONE NUMBER: (336) 335-7363
+DATE:         2/10/98
+NUMBER OF PAGES INCLUDING COVER SHEET:            3
+SENDER/PHONE NUMBER: __June Flynn for Erie Brown/(614) 466-8980
+e            SPECIAL INSTRUCTIONS: ——
+you.                                       OF                         OP}
+# PLEASE CONTACT SENDER
+‘ASSOON AS POSSIBLE
+NOTE: THIS MESSAGE 16 INTENDED ONLY FOR THE USE OF THE INDIVIDUAL on ENTIYY 70
+‘WHOM IT 18 ADDRESSED AND MAY CONTAIN INFORMATION THAT 18 PRIVILEGED,
+CONRDENTIAL, AND EXEMPT FLOM DISCLOSURE UNDER. APPLICABLE LAW. If ae
+reader of this message is not the intended recipient of the employee or agent responsible for delivering |
+the message to the intended recipient, you are hereby notified that any dissemination, disribusion,
+corn. or comefng cfs eamueon In) amet setety poh" you hv
+rrogrel tis comuaion la cor, pase wei ts inmediely Wy liens ea ara | D
+Grgnal mexage w us oe ales low via he US. Poul Serv, Thankyou fer your] NO
+al me                                                                            =S
+eee                                                                                      S
+S
+3
+Sete Ofice Tower! 0 East Broad Sree Coumbus, Oho 42215-0428
+wenagatuochun
+An Oppo Eye
+own                      |

--- a/dataset/validation/_md/markitdown/FUNSD/82200067_0069.md
+++ b/dataset/validation/_md/markitdown/FUNSD/82200067_0069.md
@@ -1,0 +1,33 @@
+.      09/17/97 10:85   ‘503 641 1696         ‘LORILLARD PTLD                        Boor
+re                   ss Sa
+FROM:                 Tp any                        way] wea
+
+wus] sees]
+‘SUBJECT:              (OLD GOLD MENTHOL LIGHTS & ULTRA LIGHTS 7100'S. PROGRESS REPORT
+necion:
+(ONLY IF PARTIAL REGION CONTA WT BISON! SCOPE
+brvsion:
+DvisO Ponind 9S 8               ONION: ene Seah PREPS: 7
+‘DIVISION: Boise    ‘# REPS: 2.5          DIVISION: Seaitle North   ‘PREPS: 4
+DISION: eugene PRPS                nvsON lna         aes: «
+## DIRECT ACCOUNTS AND CHAINS HEADQUARTERED WITHIN THE REGION
+(ns + STORES) STOCKING No OLD GOLD MENTHOL LIGHTS OR ULTRA LIGHTS 100°S
+ee
+   A A a
+Hexas -Porimnd | ar 73 [a
+er
+a eS
+[Darker tae st
+a ee
+a a |
+a
+a a a
+o
+8
+8
+8
+S
+3
+s
+g
+Bt: OGMUS-TEte                                                               Page1 of 3 Pages

--- a/dataset/validation/_md/markitdown/FUNSD/82250337_0338.md
+++ b/dataset/validation/_md/markitdown/FUNSD/82250337_0338.md
@@ -1,0 +1,50 @@
+# COMPETITIVE PRODUCT INTRODUCTION
+# PROGRESS REPORT
+
+To: Sam Zolot               MANUFACTURER: B&W
+
+FROM: D.. Lando               BRAND:      Kool Waterfall
+
+DATE: 2.Dec.97                ‘TYPE OF PACKINGS: All Packings
+
+REPORTING PERIODS:        oct.        Nov. x     Des.        Jan,
+
+‘TEST MARKET GEOGRAPHY:       Divisions 621 andar (us iscon sim )
+
+PRICE POINT: FULLS _PIVS (Indicate Distributor's Cost Per Carton)
+
+(SALES FORCE INVOLVEMENT:
+
+“They have crew.worked distnbution, and itis reported that they may crew-work i again. Sales force has been busy
+
+promoting od style packs to clean up inventory All POS is being converted to"B* Koo.
+
+DISTRIBUTORS - ACCEPTANCE/NTRO TERMSINTRO DEALS/INVOLVEMENT:
+
+‘Al accounts have the new packaging. twas nota problem obtaining new datibuton. All accounts appear
+
+to have 100% distribution of new packings.
+
+CHAINS - ACCEPTANCE/MERCHANDISING:
+
+“This has not been a problem. New packaging is just following up on the old “packaging”
+
+INDEPENDENTS - ACCEPTANCEIMERCHANDISING:
+
+Very well received. The ol packs are being consolidated and promoted in select etal ocations at 40¢
+
+fVS4.00 off cartons
+co
+
+ADVERTISING - EFFECTIVENESS OF POS.                                                                                          Ss
+
+“The theme “B" Kool has replaced all previous POS. They have effectively replaced all old POS. New                      x
+
+oor signage, hour signs, postr mats, and clocks have the new design. "B* Kool also appears on blboards               °
+
+in Winois.                                                                    On
+
+ining      oO
+3
+
+## PAGE 1 0F 2

--- a/dataset/validation/_md/markitdown/FUNSD/82251504.md
+++ b/dataset/validation/_md/markitdown/FUNSD/82251504.md
@@ -1,0 +1,35 @@
+“41y0s/e7 11:03 epe1a 884 oses        LORILLARD_TAXPA +++ GREENSBOR       @oo2/003
+Retail Excel Progress Report
+Submission fr:                                                                      Distribution by/to:
+uly 3       )                                            (OM to RSM 1st of Month
+August29()               To:          R.W.Caldarella       RSM to RW.C, 10th
+September 30 ( )                                 oo: DOS.
+October 31 (x)           From: Kent 8, Mills
+November28 ( )
+December30 ( )           Area: § Region: 17
+Acceptance/Response: What is the retailers response to Lorillard's Excel
+Merchandising plan?
+‘system we have not heen as successful, The P.O.S. requirements of the P-1 Plan
+ne
+a
+Independents:
+~         —
+# SSS
+Hardware Evaluation/Effectiveness: Comment on the assembly of displays and
+application of shields:
+sanceming the inability to be flush with the counter andior up against the register.
+ne
+Pennanent Advartising Evaluation/Effectiveness/Acceptance: (P-1/P-5 & C-5_
+Plans Only:
+
+u               ,
+a
+a
+—        ©
+
+nD
+~
+a
+a
+o
+5

--- a/dataset/validation/_md/markitdown/ICDAR/cTDaR_t00014.md
+++ b/dataset/validation/_md/markitdown/ICDAR/cTDaR_t00014.md
@@ -1,0 +1,38 @@
+2 TR Se seen tener  ree                               P       es   i        eer          e  27:
+|                                   :      CONNOTATIO REDINTEGRATIONIS   co; an
+|             ;            4d. Be          Appertinertiarum infrafertis Sy) (fuinnen Lehinect 7h hegre  Colonis in   |
+             |                                   Ji €¢                                adjuflationem Seffionis affignatarum.     . : |
+:                                         ee ae le (ie) tie | 8 ieee Te
+|                a Dele   hho  oo, PA     ,             |         lor ica ae Fundis Defertis; conga Deraina lit | Remanentia | rem Competen ||
+ren; Vetdanrve Doe pacfone na Droge nepohte         ce     BT    Lappertinentis |    __ [ety ern |      |      | a
+|       i colar wera a eee fey MR TT Tue Ti
+hi a         fromete $2 2 fre Doanajtts’ Prev’ Vefenrh, |       EAL :
+         ali Bridzpehz lei: Drove pofckteh Gybhie     [1 Wrermalbseersnlimialigcerin|ierermijececcy | i
+            kijn ante amu ovem Mohit na tmefito Dovenne       |  i    ‘     |             a     >|      i ia
+oo Davai Milefivione doter Sane        |     |     @  Mal   |     |   : Pie
+He bude: eaberve Taken: me jedan pt, nage          |      Ler ra yt yy      Baeee |
+'            [fond wu Thhed Gednih Kah Vazneh Tepahov        | I 9   ga, | 7 OME |   I. Js [Raat bag .  Al BS
+         thas’ Dlacodines fe  james’ Seapodi deny      A Seog oe           | bap
+f           JS  i di           Ve         ]            ae oe j    |   |                  | fe
+chens tmferwerimud.        | 2)| Clidguoe aie a se |. Te 4
+'                               t   N             :                     |              ha     S|        ls |  Katte alice be euler ce legion Fao ie  3
+/        — Vraainns pon Bri 24 $0      | Pal leg «| 24 «| | mane  Wy
+é        PZ, ~ One S$ppo Bret 107 + veneer YES * »         ;    sd «| Al fe +] - LEE gis PO a
+)       .  tleamuo  Sygnaturn Ki WCC: Die i Gian       |     +     |   |     |     | eRe
+       en a     “s     de Ue coe GE GRR eae:
+        A= 1778:   BN  AC  ch,     Ve       |       /    Pees. cd woes ala J.
+Diet ra cabd tosh   17] Aoi. Verh, lw | 1 || -f- si ae  |     | *)
+itofer.     nb Merb    !   i!    el |    |    Hd tee
+|          Keni    “| al Vande, Wey. eg fh || | > it ey ig
+      eo” eae | 4 Sele Hr the 8 |   ‘|   mid
+.   Pe OG ee  10} ely: Juin eo |
+,          Leemncsovag thin Baek h Hotes Fae 49*          |       | |      i ||           ie
+ng A pO esti abides, || EE t &
+
+:             ro,                  /     as                   a              h |G Din  |< Thonn
+>  ty ams  |         % a2 beh b4.|-|-| 4 EG; Jibt Hated
+| eee  AEpfoc  pZ           | | mt Sata Memeo |=) 4) €) fo) I        ie
+aa 08            gift          |   | |       moti ttt tale obded |e
+[                        Ee Al   vine scien al   Wi) it  | 4
+
+Pe | a                         !              {ial

--- a/dataset/validation/_md/markitdown/ICDAR/cTDaR_t00015.md
+++ b/dataset/validation/_md/markitdown/ICDAR/cTDaR_t00015.md
@@ -1,0 +1,36 @@
+| wo mry' as fier     pete cata, SSM Some TY       oe fe ae | tem Geral Hy
+<i   ET   _sppertinentiin fp etl +8               ll NOMINA _ |/poftfundualibus     “ae pes ie      rp fies 1)
+SEIS eHelersle el] SUSI eISle 378 Sl SS) ele! § =    Ave lS1S/8 (21 8/8] ells] 2iel3/s]el allel gielelelel
+Ad lal dat dol dd             Pritraetce 4
+,    is       ETP EE UE] sofaedetalab LLL EE da Lb
+a   &) Baharccgs!     OO Un eee e SEN RONG Te PSar VY ABAAnLE
+blond) shea?    6 2 Ce  Grids: | 1g     | Piet fells 2 Yeboah dedag| |
+‘Gapdorad TERRE EG AERA UURa Gena od ia) V4 «|| 1] An AA bh)!
+‘eee  eaasae  |  eo alee Bee.) VAL lL PL TL dL.   al  |.
+ 29) Segth: clraan.  eer ree etl ete) Pl sppyst   ||    |   i eo  “ sf 7 1
+| Ae  Wdlod .\ er    lege ae ae    |    | |.  a cM Ok | eer sd ec |
+. taeda   ed oe el Pd Rekegt be bd ie   !    ag                |
+Seb LEE all TT @g daladal of ate \Didel Aull Ayah ||
+%      3  | |  | he | ||   | Bil |     On  Z   - tee    | Og  i;  ‘| TleblesnchA   i!
+:     od We: Sn  [4 Febebldebs Pept ep fele| [ola Que sgandpig. | Lf    |         ie    i.
+|      ix   Mcbest lekcl ted take [he] | [pA Macey Yecgamenelie | foot tot et ep ebabebefief tate te pete g
+92; Maneu) Suck 4 -|\4)1| -| pated Pees Hef} loll Wp seh Wopmeal a -ledlad                  |
+59\\ 43 Aller  |  bk de SIP Seeeent ia  ripnctti HCG. | He} ete} | ote feted ef e[ ey. |
+aca  Serre tr. | ast. Aecotoid 21H) J of eh LL eteteL tsp ede fete
+J Nich. holla.  Sc offs] -f- | 4. He | |   : ie    |     |   |,       |      }
+g    |  1  Seaecn |  |  | (92,| Mastin Hadly $4 -|-\2 -| - ian hed el dw betel OI
+ul IZ  |    |    oe ee |    |   | | Pe fey, Wladtoxr   |.  “ft-o] tak st ae | [el
+fl) Wick. Jef ..'\s4 28 -\ 4  Reis, be  Beeeil     |
+' “a “oulaal Pee rey |      Redtad 40\Achr3 Jamil? Doafkanese. |
+ Senjawissst 94d | elf fe |     cee   WA       | al    “   See      Vf
+lean.  i,  Meee ec eneeae lil Someatey 414 )) 2-1) pebble beled al
+err Hala tel LEP. Lf deers Paneresar ne:  felled Ld |
+nt |   4   y G  .  I, Dacsnin nn 7h Abe     |    |     Orb   He ald  C ff, r PAVE ye,? »  Jat : |
+@| Sopdet |  a  speRaaal    et,  Bd Syn Lcd. / oes Bull
+é  ;               a ee eg                                             }
+Sinan Bearofathe|-|+| |] 4+) -f "ABE     ha        Coleneh ofacrsaye \kd| AP \ Chuckinar Yep Nareed
+i   |  |  |             eo ui a P         |   i a7
+|      TOE | ere. ||     area     dba
+    Ca, | sh e| -fo} eile] «Il Spel. Wg ls fist  or fie ih  |        ee a Lal AG | ee |e Oe On | S's
+i      |    |              |  {feet Lad | alg. bail
+nt

--- a/dataset/validation/_md/markitdown/ICDAR/cTDaR_t00016.md
+++ b/dataset/validation/_md/markitdown/ICDAR/cTDaR_t00016.md
@@ -1,0 +1,44 @@
+|               ‘etc <i —       a              |
+|    / NOMIN  | cine ees rm fee ee   y Prun py att Me
+|             :     A | ottindantine     fie] Stseee | ems angi mg    Spit, Minaye Searle, 2 Wei aga Bc ern
+yoo eel eee]   Dee ee ate fs Maes hal te os
+I  |         HE elf] 8 [2/é|/s] é SS |              Low is ohana casa tae Pharlled Fenda Otane Zenih
+pee AEE E||& ial: i : ail ‘s/E) a) al =a       Com Clapir   | Oachenye Satin, C2 pt oharja. Semluch, Desctigy |
+|        |    eanfla. ashok  te   PALE  | IMENA  Wetiat  ; (ie.   TTTLT te
+   /         | 4  oe   ,         hs | |      \EiPRIDOV   |B) a |g ae s || 5 Bi§ :    a         OES
+eas Fiageh | - PraevOReee  rhe | |    |      VEL IS! S Bla lal i 2 | a st oretal tee  leis
+v2      |       .  | ros Weal ited ete, |e     ils     | q a  Ef east eal a Pi 8 Xe S Ble o/s 3 g  les
+          SV ep:  oth   |.    ,               |  od ef Bod al } myo    — IN ere | BIR IW > A| (812 B| (eS
+| Ales tafmdcy |. Ce meh ak:    ee a Meee es Huge
+:   li      Jeff effi ebefe} ed      i               ba   |   1 a i ae lan Waals
+eta atl Maa     Bent tay
+      ie aia   Fai  =a 0          g  Pde yd a  |   i.   WEA:  9%                  Br   Ch. |               is  |
+|     G\ hal. FeQetled dlaval ||.      |      aia hs Bis. atk | | el ahogl |         i 4
+A          Had      |              |       t2\| Phila:         ah fl oe yal os               |
+Awa | i Oa         |     Wye Chil, Rrech         | ila  Hf SPs            ae   |
+c cameo nnn TTT, Wee ee asl  balal salelat (alate | |
+|      _———     |              Alii WO] Fegehe’ Bebeen PA miles bused gh ae oAly\ | CE 74 9) -
+oo  |      (ma. ast lone 1-1-1 al de  Lt      Weal ack    | ALOR. | % Al    | 4 2117 big  thes fal be   |
+} |      AbapanePAT PAGAL la) il ag | ars eg | 4 cou blaalilal.| dali
+Bl ga nesrseptcotpanipnl Perea ‘pane ias yf
+Hi  i}                   BY |     “ne   4   1,                      \             fa.6    4 #2     .   |     }    he    .     Zoey   i
+|          Deki ried sped et sacaal lipamog b 444-|elslolaalel el atta
+|  pate  y,   4   | Abell aed   ll BATE | | Mpg |  ae bi ass Bb’
+         iT     S  ‘   WL each S63   eae | eal  r    Taal y   - Gk Vad ail       ‘Bug
+        At?    eg  A   AY [2 7   A UZ,   | ‘    Vauk .. jr 192 sire ies Bye 9.    34  s   |
+| ee ee TT lh (Re) ae Ho.  A ea tA sili onl 7. «|    Ms -
+|          |    bbled te) kato ele    ye. | NG        a2 e5 4 #004 &    14 | 0424 24 te. |
+     :     |         | M    tH  is    ;       |   f  di Suxiefinect.  uals i air a) a ‘
+|   f        eg sh    it lef  | SH | 2) A\1928 05) 74 481 7.     r
+|            |     beg het L   AGIA J  OT |: ce dacaees  a bn  ’  ae. we 4 14 4 74     |
+i          |      y    YE ey A Wopetan, Hal and          )   4 | G94 o9.Me gl 7        eg ow
+|           |  |   u4 Ze  M1 TAD Zale ha Al 4  |        Sabie! Bede;    9 Os HE a | gat ated     '
+t                                 1                Ae  aah                                          2      ai Go bes        oe)                        |         7
+|    |        ae (od 2u3 Las      (ad a sedges)
+|        | |          SD i bee Gimsiy) 22 || danas 9) 2 3         !
+7           |     |     tT eee ga cl sll ol ig    -| 2
+       W)    }    Wie heh gy 4 “ bias) 2   /
+Vee        ‘                      yy ma‘     |      one a   3     ..   Aq  f  i
+on |                                |       I      |             [SS         at    a    -           .
+ae               , |   |  |    | |    | |      (ame A 2s Whe  a       7     ;
+ny ee bes | {   ¢   |   | |    i    ‘   - | PH Ey, 394 .  I oe pt   at

--- a/dataset/validation/_md/markitdown/ICDAR/cTDaR_t00080.md
+++ b/dataset/validation/_md/markitdown/ICDAR/cTDaR_t00080.md
@@ -1,0 +1,56 @@
+— 7   .      °     scons  i         oe                 "sd
+;       :            *      ey,      ;                 =      ‘    :                 Ae    Re    A
+ii A Mert,  : = Cciles LAY JOA sociale Teas ereshack A toy A¢¥.
+satis          3     Pee                          ae.
+Tuy     p Te  jaf                          ¥                  ee ———                        ;
+Y ie taal fo [a
+Te     i         ‘             sales Kh :             Ag ATI   ,        g thi  o    —<— FF
+i.        aS                            4                                Wf   .     PCLAG   i
+Wedge 1  i ee
+POV! auaataa A Gogh CMinpir 597, ME taf Ors FE      Ae
+ii { Bry. Seca rnut as   Moy Siben ttf,    PY 4 4 $     3 ry PY     , fi    SY fries, hy bs
+bs We.         I"                  5        ate  th Ce    sie ag gay, eo   g   he         e /
+fpr ©           f.      /          Pig. he fe      ibd Sie
+&          or 5 gE RAGE CIM J     m   A Ree oe     : a  ~         .j ’     oe  at
+feo! Pay FZ) gerd Oud | ee Care           Yr ee
+in| Vine, srk     4A AP p 7 pe 7 oy a         ALeones ie a      ¥ y/ Selly fled)  |
+Rave ——— | Wc Ginbsor | 9. 7          ay li,
+femme |         1 oe *             LF PWV GY Ay                 —
+20 /Von                Ahn? LIOR,    WA   itp     Lid i *                    |
+iti ee                                 Prd fdl iro                   _
+i     Betis SS es Se      Os      a    taf     |                  |
+aigg IS peed ad
+“Rates!    of £5    :         ae i      aF       ‘doa shy           .         anges     Po
+WWa~  wt loys  Mh Aur 7!    by th.     Y,     , yee te  7 i
+jg eee fy ef                      oh           |                Uy
+onl  bro. | BIL 77   Mei; ey ey BY  £ S  fi    >    la    | 4 -  Y]      |
+Megastore a A heey       bade ae          z
+PT                 2 gee To                  f
+Tim Yoong. | Bay Mitte ag inn |p, ape
+1M         of,  OD Mifyis pu Stee      ie Eo  of:  533  { if     ph, i
+LAO acute aa                                    j            Phd      tL a
+7          ea                 LbOF | Lay,              ee        7
+ae °                                     p-              eee aoe He               ae
+Ieee Cece!   x    is     bf dee  f  7:  om  Q*   Pa                    y
+ie  :         phy:  fe y    hE: i  ‘ae f   0,4 Yar    Sig        4  Lf          q
+(fies    3 ye Z 7  N,  Lo, Snaritt focy Y J -| Saaatagly,   :  ,       -   A     OS       — j
+Mea «| fg    %                      }   4      ‘                                  *   ‘ f
+sl mil AE: pb to                       :                     A
+7  Ben usin      = Yasar          pnt Ly hue           1D.
+Ran aie
+of          ‘            f            -        t   4                      :       et
+ae                 at Toe         =                    oy
+4          Jp f*     ,  be he     je   nm Boer          Is i?  .  up
+-—          ,   Mi fSbad BS  7 Ate Be   ih      :           ————
+4 ey          hor                     Sou fre! | Pb allgriagy A
+Yr ROO)                      + | oesnanypacy.                    Lo
+|     id   fi i,                    ae             ;                                          x  4 ¥
+8 Cuoll     2 |S Az fund     =    |         |      “i
+Gy Foe LT ee | Pre initel -  y
+je we) a    nto d    Q  WIE SSS       Meg ( fF.   Ps      neck  paecieeey | ;
+| etfs     :          ahr  of    OB &                f hen     Ar            oe       at: a a
+4h       (7   A                         4     A                a»   O07    Bees   t
+|              D. Rndtficart loafer fons  :    ae | ES en
+       Of /       Se ae         a     . pS ae
+;       *       ev: flaws ee           ;     a           ce       5%   5    ce "ae = it
+We eee ae ee ee        ae eee Se

--- a/dataset/validation/_md/markitdown/MARMOT/10.1.1.1.2006_3.md
+++ b/dataset/validation/_md/markitdown/MARMOT/10.1.1.1.2006_3.md
@@ -1,0 +1,101 @@
+09                           these consume 0,99 CPU. That is, task3- misses
+
+ra            praia        deadlines and the inverted pendulum! falls down, This
+
+og Ltr                     c                                explains the fact thatthe cost function in Figure 2 goes
+
+.                                to infinite. Note that under RM, the task is not
+
+Bod                               schedulable
+
+i                                + EDP: EDF is « dynamic alorihm in open bop
+
+§                                           Which assigns priorities to tasks according to their
+
+i,                                   Beavis dedine, Une BG’ holler te
+
+schedulabiity condition is given by U = 1. For our
+
+4                                         simulations, since U <1, the task set is schedulable
+
+and the three pendulums can be controlled as it can be
+
+1                                                           seen in Figure 2: the accumulated cost reaches a finite
+
+a a oe       value, which means that the deviation caused by each
+
+icici al ak aed                  perturbation thet affected each of the three pendulums
+
+could be adequately comected. ‘The performance
+
+with the difference in performance due 10 the we of sehieved by EDF is also given in Figure 2 in tems of
+
+different scheduling polices, which is the objective of our      tie coat BocHonsreadting a valus oF W2754 at tho
+simulations.                                                                   completion of the evaluation interval
+
+‘The perfomance of each pendulum is obtained by the
+
+following cost fmetion J, which measures the enor ¢,of 4 LER: LEF is a dynamie scheduling algorithm in
+
+the pendulum weighted with time ¢                   closed-loop, which adjusts the schedule based on
+
+= fre2enae                continuous feedback of each control loop. Under this
+vin= |ehom                         scheduler, inthe simulation we ebain thatthe thee
+Note that 1 sets the duration of the evaluation period,        inverted pendulums can be perfectly controlled. As it
+
+‘hich typically should go fen the’ perturbation sirival      can be seen in Figure 2 the cost function of LEF goes
+
+fine (0m the integral) wo the setling tine As higher     blow the cost function of EDF, meaning that for this
+
+values the cost function gets, the worst the control palticular simple simulation set-up, LEF performs
+performance (because major deviations occur or because it      better that EDP. Note that the final cost of LEF is
+
+fakes more time forthe inverted pendulum to recover from          0.2490
+
+the perturbations)
+
+C. Discussion
+B Results                                     ‘The exact cost for each one of the three pendulums
+The simulation we run Keeps the following time under each scheduling algorithm is summarized in the
+sequence: at time =O, only the control task controlling the Table 1. RM fails in controlling the thitd pendulum, EDF
+fist pendulum is released. After executing alone, at time and LEF are able to control the three pendulums, However
+
+12. another contol task is released to control the second LEF gives the best control in terms of the cost function
+
+pendulum, Finally the third control task is released at time
+
+f4, The three controllers run in parallel until t=7. Before Tate 1, Cost forthe tac inverted pendulum under cash
+
+the release time of each control task, the corresponding                 different scheduling policy
+
+pendulum isin equilibrium, At release time of each control              ———
+
+fask, the pendulum suffers a perturbation (of equal      Scheduling Jy Sp
+
+magnitude for each pendulum). This simulation pattern is          RM 00033009308
+
+repeated for different scheduling algorithm: RM, EDF and          EDF 0033. 00930 0.1769
+
+LEF. During each experiment, the cost funtion presented          LEF 000330812 _o.1645
+
+earlier and the resulting schedule are recorded. The cost
+
+function evaluation period goes from the beginning of each This results shows that scheduling polices that take
+
+simulation, =0, to the simulation completion, at t=7. For advantage of the application dynamics and are able to
+
+cach scheduling policy, the results we obtained are agjust the schedule accordingly ean provide, in. some
+summarized inthe following:                   Specific scenarios, better performance in terms of the
+application (control performance in our case).
+
++ RM: RMisastatic scheduling algorithm in open loop, For opertoop scheduling approaches we identified (see
+which assigns priorities to tasks according to their Section 1) three main negative aspects: low real CPU
+request rates. The cost function values for the three utilization, the lack of feedback mechanism and poor
+pendulums are shown in the Figure 2 (note that Figure gdaptability to the application dynamics. Our. strategy
+2 shows the accumulated cost function, 2, during the optimizes CPU utilization in the sense that control tasks
+evaluation period for each scheduling policy). Under are executed only when they are required. That i, they are
+RM the schedulability condition for our experiment is executed when the controlled plants suffer perturbations.
+given by U < 0.78, Taking into account that task Otherwise, they execute with the slowest possible rate in
+execution time is 4ms, until 4, the processor order to give room to other tasks with higher priorities. In
+utilization is 0.71 and the control performance is good. addition, our approach is based on the idea of feedback,
+From t4, the tree contol tasks run in parallel and which offers the possibilty of taking at run time the

--- a/dataset/validation/_md/markitdown/MARMOT/10.1.1.1.2013_63.md
+++ b/dataset/validation/_md/markitdown/MARMOT/10.1.1.1.2013_63.md
@@ -1,0 +1,38 @@
+4s
+Table 1—Activity, employment, and unemployment rates forages 15-64, by sex and
+urban/rural location, 1990-95
+Cs
+Rate             1990 1991    199219931994 1995
+Activity rate (15-64)
+Urban Male        no   108   69.8   108   105   699
+Female        24    203    19.1    203    202    195
+Total         473    457    444    457    454    448
+Rural Male      782   168   163   163   76.1   163
+Female                 347        293        261        240        254        230
+Total         564    530    50.8    50.2    510    497
+Total Male      753   749   2   7   BS   B3
+Female                 290        252        2.8        23        230        214
+Total          52.    49.6    478    48.1    484    474
+Employment rate (15-64)**
+Urban Male        670   653   647   649   649   646
+Female        168    154    143    146    146    14.1
+Total         42.1    405    395    399    308    304
+Rural Male      45   na   18   109   107   106
+Female        316    262    28    195    204    181
+Total         330    493    469    453    458    443
+Total Male      110  69.1   68.5  68.1   68.0  678
+Female        247    aul    189    172    117    162
+Total         479    452    434    428    43.0    420
+Unemployment Rate (15-64)**
+Urban Male         69    1    13    84    19    16
+Female        248    244    249    279    280    276
+Total         Ma    14    na    127    124    119
+Rural Male       47   57   59   10   A   1s
+Female        9.0    108    125    187    19.6    214
+Total         60    mM    16    98    10.1    107
+Total Male      57   66   63   16   1s   1s
+Female        147    159    173    27    2.1    241
+Total         82    89    om    i    Te    113
+Jouce:CAPMAS,LFSS,——SSSCSCSSSSSSSSSSSSS
+Notes: Activity rate = labor force/population x 100 percent; employment rate = employment/population x
+100 percent; unemployment rate = unemployment/labor force x 100 percent

--- a/dataset/validation/_md/markitdown/MARMOT/10.1.1.1.2013_64.md
+++ b/dataset/validation/_md/markitdown/MARMOT/10.1.1.1.2013_64.md
@@ -1,0 +1,21 @@
+46
+Table 2—Labor force participation rates compared, ages 15 —64
+Sg
+_ SSeS 99S SCSCOSIOT
+Wale han SSSC~SSSSC~—~OCSSSC
+Rural                              792                              76.3                              154
+Female Urban                   293                    195                   262
+Rural                    539                    23.0                    173
+‘Table 3—Unemployment rate, by sex, education, and region, economically active
+population aged 15 ~64
+,_.-. TRS 19—S—S—~—~—~—~“—siES TTS
+With search              With search            Without search
+“Tran Runt Tos! Urban Run Tot “Urban Rural Total
+Mie
+Below secondary      13, 04 07 5402033    M3300 47
+Secondary andabove 14126001893. «12.7s9 130169147
+Total          16° 75 78 84 S54 68 101-7788
+Females
+Below secondary     4103 «0.70 «9816S 7S 1732-202
+Secondary and above 30.9 $7.7 40.0232 «405 8S 53.2384
+Total          276 214 24.0 2012302139732.

--- a/dataset/validation/_md/markitdown/MARMOT/10.1.1.1.2014_4.md
+++ b/dataset/validation/_md/markitdown/MARMOT/10.1.1.1.2014_4.md
@@ -1,0 +1,36 @@
+3. Ifa change is declared, then (a) the point pat time remember all the data points. Instead, if we can make the
+L-changeResetWindow is marked as a change point, system forget older points, we should be able to detect out-
+(b) all points after it are unmarked (they are not out —_Tiers/change points better.
+liets anymore), and (¢) the model estimation is stated
+afresh from p,.
+Table 1. Parameters for deciding outlicrsichanges. Pa
+rameters with * are user-provided
+Tae          |
+Sina | 2 tat a ea                 a                          is
+sntrortrait | enim ny i tr                    W
+—_          Scigcwsencame "="                   S
+een mare soutien amd dens om f                   Figure 1. Effect of older points in RLS-based
+ey          Re Date enuccemone b            outlier/change point detection. (a) saw-tooth
+___ | Sesto ac ofertas                  data stream. (b) slopes of the line segments
+crenimseniot | LeRoi cr cn roe       in the sawtooth. (c) slope estimate using
+crmrovrdeds | ute miner of pon wat the nena          RLS. (d) slope estimate using a moving win-
+mecefleatececimet cries | dow of alze5,
+ea          Foeiee See ae Tee            One approach to forget older points is to have a moving
+oo         Sear ece oc EEA       ‘model over this window. At the same time, we would like
+3.2.1 Using Forward-Backward RLS
+‘One method to achieve this would be to derive a backward
+3.1 The Naive Approach                                  recursion and altemately use the forward and backward re-
+In this approach the RLS algorithm is used to compute sions as follows,” Suppose the current window spans
+the model parameters over all the data seen so far (unre-_‘{lts-- fw) When a new data point comes in at fy 41, we
+Geeaciae)                                                      use the forward recursion (equations 7-9) to derive a model
+Inivally (forthe fist few points) this approach may be "the points in [fs..» fy ty 11) Then, we use the back-
+succesfl in detecting outicrlchonge pots, As more Ward ecursion to remove the effets ofthe point at and
+points come in, RLS estimates the model parameters con- ‘its get a model forthe points in [fzy...«fovfust
+In what follows, we derive the backward recursion for
+sidering all the points seen so far, and thus it gives equal                      5
+‘weight to all the points in the unrestricted window, Asa RLS. Suppose we have Ania and Pia over certain data S,
+result, the changes in the dynamics of the system may be W#eTE
+hhidden by the dominance of the older points. Figure 3.1 il-                               a
+lustrates this phenomenon. As a result RLS by itselfis not       Pua       BT)                 10
+sdequne, Te pblem w de tothe fet dat RLS esto           Hey ane)                      an
+4

--- a/dataset/validation/_md/markitdown/PUBTABLES/PMC1064078_table_0.md
+++ b/dataset/validation/_md/markitdown/PUBTABLES/PMC1064078_table_0.md
@@ -1,0 +1,10 @@
+Cases and controls in Carolina Breast Cancer Study (CBCS) analytic datasets by race
+Atican-American                          write
+Anayic dataset                          Main exposure                 Cases(%s} Controls 6) Cases (8) Contos (8)
+BCS, entre                            Beth order                     385 (1000) $92(1000) 526(1000) 488 (100.0)
+(©BCS, bom 1948 or later                                          191 (59.1) 198407) 235 (447) 181 (3085)
+Maternal age dataset        Bithorder, Matemal age —-«107(81.)116(349) 173 (829) 121 (26.4)
+Paterna age dataset        Paternal age         95 (284) 100(90.1) 171 (928) 118.(25.8)
+(©BCS, NC bom 1949 o ater                   90/206) 96 (289) 112 (218) 85 (18.6)
+Birthweight fll datasot                Bithweight                    861257) 89268) 110209) 7817.0)
+Binhweight, resticted dataset        Bithweight                 49(146) 970013) 98(186) 63188)

--- a/dataset/validation/_md/markitdown/PUBTABLES/PMC1064078_table_2.md
+++ b/dataset/validation/_md/markitdown/PUBTABLES/PMC1064078_table_2.md
@@ -1,0 +1,19 @@
+Birthweight slistbutions and odd alos for breast cance in Aican-Amercan and white women combined
+Minnay ated OR      Ful aja OR
+
+Canes Conte ——OR" «SHC Gatee Canto ORY 95H
+Ful bthwight dteoot  a=08 | n=t07     nate nator
+Lower tree    7  7  09 0618 72  10 oer
+Conta te   20  st at  © st Ret
+Upper tre    8s  86  07 o&t2 80  807 ona
+Mean 8D (@)      anon #850
+Median)       sea
+Range ()      toat—4ea
+Resticted dataset   antay—— n=t00     nava nnor
+Lower trae    se  “  os os17 88  4 10 os09
+Conta te   ae  a fet  ” a Ret
+Upper tre    0  25  10 0s21 98  2508 oat
+Mean #80 (@)      ano. a2
+Median ()       eae
+Rage)      2081-4621
+‘body mass index >25 kg/m?, <Tertiles are race specific with cutpoints denved from controls. White women: <3062 g, 3062-3458 g, >3458 g;

--- a/dataset/validation/_md/markitdown/PUBTABLES/PMC1064078_table_3.md
+++ b/dataset/validation/_md/markitdown/PUBTABLES/PMC1064078_table_3.md
@@ -1,0 +1,13 @@
+Birhweiht strbutons and os tos for breast cancer among Aicar-Ameian andwhte women byece
+en            rao
+Gan Gatch OF HG Gam Ganah OF HG Gm Gomes OF WHO Caw Goma OF HONG
+Comune 8   oe  am  7 MM
+messes         ome
+sn    on       ne
+oe                        4734
+sioess0) sates      cae
+i
+sn    oe       ne
+nents    ai       a
+ay ee en en SE
+ea a ae oe rs acre ae, we hi ee

--- a/dataset/validation/_md/markitdown/PUBTABLES/PMC1064078_table_4.md
+++ b/dataset/validation/_md/markitdown/PUBTABLES/PMC1064078_table_4.md
@@ -1,0 +1,21 @@
+Parental age distributions and odds ratios for breast cancer among African-American and white women combined
+Minimal acusted OR*                                  Ful adjusted OR®
+case              Conti OR-—«8BHC!_—Case—=—Contol-—«OR—— BHI
+Maternal age ears      n= 260    n= 296             n=263 =a
+1948            at      a1     18 0934 90     2 18 og-a5
+19-22)                           st                  80            Ret                         4              7 Rel
+29-27            a      49    20 1880 as     495 20-80
+28-44           m      n    25 16-40 100     830182
+Mean # SD        2estes 252467
+Median                                28                  23
+Range                              17-48             15-49
+Paternal age ears      n= 206    na2ie             n=251 n= 200
+15-22            39      38     10 0648 38     318 Ban
+29-27 (ro)                          73                  0            Ret                         ©              Ret
+29-34            27      o     19 06-21 a3     e212 aren
+95-56            o      4s     16 0926 61     415 oraz
+Moan # 80        sorz1) 298278)
+Median                                29                  28
+Range                              17-83             15-86
+Soetatos or 1) sjased GR powsahocl cam £680,000 hd ith crdeAdstoralcovattcs or aly agusted OR aa boy ass index
+CORES 25: UY BRINE Ses, Beaies Ole INCRE emmy, Riel ONT

--- a/dataset/validation/_md/markitdown/PUBTABLES/PMC1064078_table_5.md
+++ b/dataset/validation/_md/markitdown/PUBTABLES/PMC1064078_table_5.md
@@ -1,0 +1,15 @@
+Parental age distributions and odd ratios for breast cancer among African-American and white women by race
+Moimayaustes OR                 Fal agurted OR
+Cue Contol OR 9B5CI Case _——Contol- OR BWI Cass Conteh OR 9BHCI Case Coaval OR 95M CI
+yews"   i   =        a   es        eae       SUTURE:
+15-18  10  7 2 0955 12  4 41 0529 18 15 27 10-70 12440 04-87
+wea   18   2 Ret     29   47 Re    789 Ret     a 4k Ret
+2-27   28  2 19 094s 88  242 21-89 27 2824 10-84 88208 23-08
+Mein#8D 286279 255270      vests 249269
+Medan   26   2        26   2
+Petoaiage = 95 n= 100       nai pate       nao n= 94      ne te2 nena
+‘yeu
+15-22   16  15 14 06-99 29  2 07 0345 18 27 10S 21814 05-28
+an   2   20 Rt     s   40 Rt    2 Ret     98 Ret
+Mon280 90926 204280     msz68 90269
+Saeco snd Geter sAdecorlcovrates or fly sduted OR ada body macs index 928 ln Nowsehod income S8S0,0, bh Oder ane maternal spe

--- a/dataset/validation/_md/markitdown/PUBTABLES/PMC1064078_table_6.md
+++ b/dataset/validation/_md/markitdown/PUBTABLES/PMC1064078_table_6.md
@@ -1,0 +1,7 @@
+Bir order stb and odds rato fr beast cancer among whit and Atean-Ameriean women by ace
+a et           raya
+Goat WAG Ge tot WHE “Gen Gas OF ONG Ge Gm RNG
+mona a8     wae
+Ty
+pS
+“ene dence, ied rp ati rd hg rena "loa pave a aie OR on Rg,

--- a/dataset/validation/_md/markitdown/PUBTABLES/PMC1064082_table_0.md
+++ b/dataset/validation/_md/markitdown/PUBTABLES/PMC1064082_table_0.md
@@ -1,0 +1,3 @@
+Imunchtochemy ndings                  alate mRNA epesson                P
+000                     >2000
+Hah erosion       3           "           <oao

--- a/dataset/validation/_md/markitdown/PUBTABLES/PMC1064082_table_1.md
+++ b/dataset/validation/_md/markitdown/PUBTABLES/PMC1064082_table_1.md
@@ -1,0 +1,26 @@
+‘The relationship between lysophosphatidic acid receptor 2 (LPA2) expression and clinical/pathological factor
+_LPA2 expression        Low (36)            High (4s)            P
+Age (ears)
+<50                                20 (56%)                              16 (35)                             0.042
+250                                16 (4406)                             3267)
+Tumour size
+11 (200m)         16 (4490)            17 (3550)            Ns
+T2E20emt0<60em) 18 (50%)            25 (82%)
+73 P80em)                       2 (63)                                5 (13%)
+Nuclear grade
+1              5 (14%)            5 (10%)            Ns
+"                            24 (67%)                       31 (0550)
+u                                   7 (198%)                               12 (2558)
+Menopausal status
+Promenopausal                  21 (58%)                          17 (9550)                          0.097
+Postmenopausal               15 (4208)                       31 (6598)
+Costragen receptor status
+Negative                           10 (559)                             27 (869%)                             Ns
+Positive                      8 (45%)                         21 (4498)
+Nodal metastasie
+Nogative                      12(83%6)                       21 (4480)                       Ns
+Positive                            24 (6796)                             27 (865%)
+Distant metastasis
+Ngati                      27 (75%)                       41 (659%)                        Ns
+Prsiive                            9 (25%)                               a)
+~ Numibers in parentheses indicate percentages inthe same expression pattem, NS, not significant,

--- a/dataset/validation/_md/markitdown/SROIE2019/X00016469670.md
+++ b/dataset/validation/_md/markitdown/SROIE2019/X00016469670.md
@@ -1,0 +1,28 @@
+tan chay yee
+88 COPY **#
+## OJC MARKETING SDN BHD
+ROC NO: 538358-H
+NO 2 & 4, JALAN BAYU 4,
+BANDAR SERI ALAM,
+81750 MASAI, JOHOR
+Tel:07-388 2218 Fax:07-388 8218
+Email: ng@ojegroup.com
+# TAX INVOICE
+"jfvelee No” peGAOSoIEs
+Date       + 15/01/2019 11:05:16 AM
+Cashier     : NG CHUAN MIN
+Sales Persor : FATIN
+Bill To      : THE PEAK QUARRY WORKS
+Address     bs
+Description. Oty. Price Amount
+000000111            1 193,00    193.00 SR
+## KINGS SAFETY SHOES KWD 805
+“OT Fetal Beclide tT T9560
+Total GST @6%:          0.00
+Total Inclusive GST:        193.00
+sippeaciaa Round Amtt 550.00...
+TOTAL:        193,00
+9000000000004 31.8
+Approval Code:000           VJ  a
+Goods Sold Are Not Returnable & Refundable
+***4Thank You. Please Come Again.****

--- a/dataset/validation/_md/markitdown/SROIE2019/X00016469671.md
+++ b/dataset/validation/_md/markitdown/SROIE2019/X00016469671.md
@@ -1,0 +1,28 @@
+tan chay yee
+## OJC MARKETING SDN BHD
+ROC NO: 538358-H
+NO 2 & 4, JALAN BAYU 4,
+BANDAR SERI ALAM,
+
+81750 MASAI, JOHOR
+Tel:07-388 2218 Fax:07-388 8218
+Email: ng@ojegroup.com
+Cash Bill
+“invoice No" PEGI 03085
+
+Date         02/01/2019 2:47:14 PM
+Cashier      : RHYS TAN
+Sales Persor : FATIN
+2 Deseription | Qty. Price Amount
+000000111            1 170,00 = 170.00
+KINGS SAFETY        ‘POO4
+# SHOES KWD 805
+“Gey T Total Tem Biscount! G60
+Total Amount:       170.00
+cecseeseneeeeen ROUNd Amt. 0.00
+TOTAL:     170.00
+VISA CARD          170.00
+# 2090000000043 18
+Approval Code:123            I30  U0
+Goods Sold Are Not Returnable & Refundable
+“Thank You. Please Come Again.****

--- a/dataset/validation/_md/markitdown/SROIE2019/X51005200931.md
+++ b/dataset/validation/_md/markitdown/SROIE2019/X51005200931.md
@@ -1,0 +1,41 @@
+hong a
+PERNIAGAAN ZHENG HU!
+JMO825986-V
+NO.S8 JALAN PERMAS 96
+## BANDAR BARU PERMAS JAYA
+# 81750 JOHOR BAHRU
+TEL :07-386 7524 FAX: 07-386 3794
+GST NO: 0oo80058e824
+# SIMPLIFIED TAX INVOICE
+GOGIANT ENGINEERING (i) SDN BHD       ~
+Recelati# CS00082258
+‘Salesperson,                     Date. 09/02/2078
+Cashier: USER                      Time: 08:32:00
+nr oer
+tem                  Qty RSP Amount
+6783               Woy 5 380 HBL
+# SR CERAMIC CAP
+2084               $84 30 380 © 114.00                                   .
+SR: SISTEEL 1/2" STREET ELBOW
+1760                GA 4 85.00 86.00
+SR: 24MIN STARWELD RED HEAD TUNGSTEN ROD
+3496                 44 3 B00 99.00
+SR: ESICUT 4" CUTTING DISC (4BOX)-50PCS
+2460                 GA 2 43.00 -86.0¢
+SR: WELDRO PICKLING GEL 1K
+9428                 Ge 4 1900 40.0c
+SR: 13.5" WELDING GLOVE- GREEN (@3}
+# TOT GT BE
+(Excluded GST) Sub Total (RM)        411.50
+Discount (RM)          ooo                °
+Total GST (RM)         24.69
+Rounding (RM) :       0.0%
+Total (RM): 436.20
+GASH : 436.20
+Ghange (RM) :       0.00
+# GST SUMMARY
+_TaxGode %@ Amount GST.
+SR               6         417.50       24.69
+Tg tal TOR
+GOONS SOLD ARE NOT RETURNABLE,
+THANK YOU.                                .

--- a/dataset/validation/_md/markitdown/SROIE2019/X51005230605.md
+++ b/dataset/validation/_md/markitdown/SROIE2019/X51005230605.md
@@ -1,0 +1,25 @@
+## PETRON BKT LANJAN SB
+# ALSERKAM ENTERPRISE
+Tel: 03-6156 8757 Co No: 001083069-M
+KM 456.4 BKT LANJAN UTARA,
+L/RAYA UTARA SELATAN,SG BULOH
+# 47000 SUNGAI BUL
+GST ID No: 001210736640
+# TAX INVOICE
+TAX INVOICE NO: 19729058
+POS: 4
+Store No.: 129077              Babu
+01/02/2018 4:43:17 PM
+A 2 double ,mint te         3.00
+& 1 sandwich venil]             1,90
+GST RM:                       0.28
+Total RM inc.G3T:            4.90
+Cash                        5.00
+Change                       0.10
+GST Summary    Amount (RM)    Tax (RM)
+A=6.00%                 4,62                       0.28
+A    ITAL INCLUDES 6.00% GST
+Use 3000 Petron Miles
+points to pay for
+RM45 Fuel
+*            F          Reet            H

--- a/dataset/validation/_md/markitdownnet/FUNSD/82092117.md
+++ b/dataset/validation/_md/markitdownnet/FUNSD/82092117.md
@@ -1,0 +1,32 @@
+y
+ATT, GEN. ADMIN, OFFICE Fax:614~466-508?              Dec 1098 17646 POL
+SAA) Attorney General
+C oe. =ae#7 Getty D. Montgomery
+# CONFIDENTIAL FACSIMILE
+‘TRANSMISSION COVER SHEET
+FAX NO, (614) 466-5087
+‘TO: _ George Baroody
+FAX NUMBER:    (336) 335-7392          PHONE NUMBER: (336) 335-7363
+DATE:         2/10/98
+NUMBER OF PAGES INCLUDING COVER SHEET:            3
+SENDER/PHONE NUMBER: __June Flynn for Erie Brown/(614) 466-8980
+e            SPECIAL INSTRUCTIONS: ——
+you.                                       OF                         OP}
+# PLEASE CONTACT SENDER
+‘ASSOON AS POSSIBLE
+NOTE: THIS MESSAGE 16 INTENDED ONLY FOR THE USE OF THE INDIVIDUAL on ENTIYY 70
+‘WHOM IT 18 ADDRESSED AND MAY CONTAIN INFORMATION THAT 18 PRIVILEGED,
+CONRDENTIAL, AND EXEMPT FLOM DISCLOSURE UNDER. APPLICABLE LAW. If ae
+reader of this message is not the intended recipient of the employee or agent responsible for delivering |
+the message to the intended recipient, you are hereby notified that any dissemination, disribusion,
+corn. or comefng cfs eamueon In) amet setety poh" you hv
+rrogrel tis comuaion la cor, pase wei ts inmediely Wy liens ea ara | D
+Grgnal mexage w us oe ales low via he US. Poul Serv, Thankyou fer your] NO
+al me                                                                            =S
+eee                                                                                      S
+S
+3
+Sete Ofice Tower! 0 East Broad Sree Coumbus, Oho 42215-0428
+wenagatuochun
+An Oppo Eye
+own                      |

--- a/dataset/validation/_md/markitdownnet/FUNSD/82200067_0069.md
+++ b/dataset/validation/_md/markitdownnet/FUNSD/82200067_0069.md
@@ -1,0 +1,33 @@
+.      09/17/97 10:85   ‘503 641 1696         ‘LORILLARD PTLD                        Boor
+re                   ss Sa
+FROM:                 Tp any                        way] wea
+
+wus] sees]
+‘SUBJECT:              (OLD GOLD MENTHOL LIGHTS & ULTRA LIGHTS 7100'S. PROGRESS REPORT
+necion:
+(ONLY IF PARTIAL REGION CONTA WT BISON! SCOPE
+brvsion:
+DvisO Ponind 9S 8               ONION: ene Seah PREPS: 7
+‘DIVISION: Boise    ‘# REPS: 2.5          DIVISION: Seaitle North   ‘PREPS: 4
+DISION: eugene PRPS                nvsON lna         aes: «
+## DIRECT ACCOUNTS AND CHAINS HEADQUARTERED WITHIN THE REGION
+(ns + STORES) STOCKING No OLD GOLD MENTHOL LIGHTS OR ULTRA LIGHTS 100°S
+ee
+   A A a
+Hexas -Porimnd | ar 73 [a
+er
+a eS
+[Darker tae st
+a ee
+a a |
+a
+a a a
+o
+8
+8
+8
+S
+3
+s
+g
+Bt: OGMUS-TEte                                                               Page1 of 3 Pages

--- a/dataset/validation/_md/markitdownnet/FUNSD/82250337_0338.md
+++ b/dataset/validation/_md/markitdownnet/FUNSD/82250337_0338.md
@@ -1,0 +1,50 @@
+# COMPETITIVE PRODUCT INTRODUCTION
+# PROGRESS REPORT
+
+To: Sam Zolot               MANUFACTURER: B&W
+
+FROM: D.. Lando               BRAND:      Kool Waterfall
+
+DATE: 2.Dec.97                ‘TYPE OF PACKINGS: All Packings
+
+REPORTING PERIODS:        oct.        Nov. x     Des.        Jan,
+
+‘TEST MARKET GEOGRAPHY:       Divisions 621 andar (us iscon sim )
+
+PRICE POINT: FULLS _PIVS (Indicate Distributor's Cost Per Carton)
+
+(SALES FORCE INVOLVEMENT:
+
+“They have crew.worked distnbution, and itis reported that they may crew-work i again. Sales force has been busy
+
+promoting od style packs to clean up inventory All POS is being converted to"B* Koo.
+
+DISTRIBUTORS - ACCEPTANCE/NTRO TERMSINTRO DEALS/INVOLVEMENT:
+
+‘Al accounts have the new packaging. twas nota problem obtaining new datibuton. All accounts appear
+
+to have 100% distribution of new packings.
+
+CHAINS - ACCEPTANCE/MERCHANDISING:
+
+“This has not been a problem. New packaging is just following up on the old “packaging”
+
+INDEPENDENTS - ACCEPTANCEIMERCHANDISING:
+
+Very well received. The ol packs are being consolidated and promoted in select etal ocations at 40¢
+
+fVS4.00 off cartons
+co
+
+ADVERTISING - EFFECTIVENESS OF POS.                                                                                          Ss
+
+“The theme “B" Kool has replaced all previous POS. They have effectively replaced all old POS. New                      x
+
+oor signage, hour signs, postr mats, and clocks have the new design. "B* Kool also appears on blboards               °
+
+in Winois.                                                                    On
+
+ining      oO
+3
+
+## PAGE 1 0F 2

--- a/dataset/validation/_md/markitdownnet/FUNSD/82251504.md
+++ b/dataset/validation/_md/markitdownnet/FUNSD/82251504.md
@@ -1,0 +1,35 @@
+“41y0s/e7 11:03 epe1a 884 oses        LORILLARD_TAXPA +++ GREENSBOR       @oo2/003
+Retail Excel Progress Report
+Submission fr:                                                                      Distribution by/to:
+uly 3       )                                            (OM to RSM 1st of Month
+August29()               To:          R.W.Caldarella       RSM to RW.C, 10th
+September 30 ( )                                 oo: DOS.
+October 31 (x)           From: Kent 8, Mills
+November28 ( )
+December30 ( )           Area: § Region: 17
+Acceptance/Response: What is the retailers response to Lorillard's Excel
+Merchandising plan?
+‘system we have not heen as successful, The P.O.S. requirements of the P-1 Plan
+ne
+a
+Independents:
+~         —
+# SSS
+Hardware Evaluation/Effectiveness: Comment on the assembly of displays and
+application of shields:
+sanceming the inability to be flush with the counter andior up against the register.
+ne
+Pennanent Advartising Evaluation/Effectiveness/Acceptance: (P-1/P-5 & C-5_
+Plans Only:
+
+u               ,
+a
+a
+—        ©
+
+nD
+~
+a
+a
+o
+5

--- a/dataset/validation/_md/markitdownnet/ICDAR/cTDaR_t00014.md
+++ b/dataset/validation/_md/markitdownnet/ICDAR/cTDaR_t00014.md
@@ -1,0 +1,38 @@
+2 TR Se seen tener  ree                               P       es   i        eer          e  27:
+|                                   :      CONNOTATIO REDINTEGRATIONIS   co; an
+|             ;            4d. Be          Appertinertiarum infrafertis Sy) (fuinnen Lehinect 7h hegre  Colonis in   |
+             |                                   Ji €¢                                adjuflationem Seffionis affignatarum.     . : |
+:                                         ee ae le (ie) tie | 8 ieee Te
+|                a Dele   hho  oo, PA     ,             |         lor ica ae Fundis Defertis; conga Deraina lit | Remanentia | rem Competen ||
+ren; Vetdanrve Doe pacfone na Droge nepohte         ce     BT    Lappertinentis |    __ [ety ern |      |      | a
+|       i colar wera a eee fey MR TT Tue Ti
+hi a         fromete $2 2 fre Doanajtts’ Prev’ Vefenrh, |       EAL :
+         ali Bridzpehz lei: Drove pofckteh Gybhie     [1 Wrermalbseersnlimialigcerin|ierermijececcy | i
+            kijn ante amu ovem Mohit na tmefito Dovenne       |  i    ‘     |             a     >|      i ia
+oo Davai Milefivione doter Sane        |     |     @  Mal   |     |   : Pie
+He bude: eaberve Taken: me jedan pt, nage          |      Ler ra yt yy      Baeee |
+'            [fond wu Thhed Gednih Kah Vazneh Tepahov        | I 9   ga, | 7 OME |   I. Js [Raat bag .  Al BS
+         thas’ Dlacodines fe  james’ Seapodi deny      A Seog oe           | bap
+f           JS  i di           Ve         ]            ae oe j    |   |                  | fe
+chens tmferwerimud.        | 2)| Clidguoe aie a se |. Te 4
+'                               t   N             :                     |              ha     S|        ls |  Katte alice be euler ce legion Fao ie  3
+/        — Vraainns pon Bri 24 $0      | Pal leg «| 24 «| | mane  Wy
+é        PZ, ~ One S$ppo Bret 107 + veneer YES * »         ;    sd «| Al fe +] - LEE gis PO a
+)       .  tleamuo  Sygnaturn Ki WCC: Die i Gian       |     +     |   |     |     | eRe
+       en a     “s     de Ue coe GE GRR eae:
+        A= 1778:   BN  AC  ch,     Ve       |       /    Pees. cd woes ala J.
+Diet ra cabd tosh   17] Aoi. Verh, lw | 1 || -f- si ae  |     | *)
+itofer.     nb Merb    !   i!    el |    |    Hd tee
+|          Keni    “| al Vande, Wey. eg fh || | > it ey ig
+      eo” eae | 4 Sele Hr the 8 |   ‘|   mid
+.   Pe OG ee  10} ely: Juin eo |
+,          Leemncsovag thin Baek h Hotes Fae 49*          |       | |      i ||           ie
+ng A pO esti abides, || EE t &
+
+:             ro,                  /     as                   a              h |G Din  |< Thonn
+>  ty ams  |         % a2 beh b4.|-|-| 4 EG; Jibt Hated
+| eee  AEpfoc  pZ           | | mt Sata Memeo |=) 4) €) fo) I        ie
+aa 08            gift          |   | |       moti ttt tale obded |e
+[                        Ee Al   vine scien al   Wi) it  | 4
+
+Pe | a                         !              {ial

--- a/dataset/validation/_md/markitdownnet/ICDAR/cTDaR_t00015.md
+++ b/dataset/validation/_md/markitdownnet/ICDAR/cTDaR_t00015.md
@@ -1,0 +1,36 @@
+| wo mry' as fier     pete cata, SSM Some TY       oe fe ae | tem Geral Hy
+<i   ET   _sppertinentiin fp etl +8               ll NOMINA _ |/poftfundualibus     “ae pes ie      rp fies 1)
+SEIS eHelersle el] SUSI eISle 378 Sl SS) ele! § =    Ave lS1S/8 (21 8/8] ells] 2iel3/s]el allel gielelelel
+Ad lal dat dol dd             Pritraetce 4
+,    is       ETP EE UE] sofaedetalab LLL EE da Lb
+a   &) Baharccgs!     OO Un eee e SEN RONG Te PSar VY ABAAnLE
+blond) shea?    6 2 Ce  Grids: | 1g     | Piet fells 2 Yeboah dedag| |
+‘Gapdorad TERRE EG AERA UURa Gena od ia) V4 «|| 1] An AA bh)!
+‘eee  eaasae  |  eo alee Bee.) VAL lL PL TL dL.   al  |.
+ 29) Segth: clraan.  eer ree etl ete) Pl sppyst   ||    |   i eo  “ sf 7 1
+| Ae  Wdlod .\ er    lege ae ae    |    | |.  a cM Ok | eer sd ec |
+. taeda   ed oe el Pd Rekegt be bd ie   !    ag                |
+Seb LEE all TT @g daladal of ate \Didel Aull Ayah ||
+%      3  | |  | he | ||   | Bil |     On  Z   - tee    | Og  i;  ‘| TleblesnchA   i!
+:     od We: Sn  [4 Febebldebs Pept ep fele| [ola Que sgandpig. | Lf    |         ie    i.
+|      ix   Mcbest lekcl ted take [he] | [pA Macey Yecgamenelie | foot tot et ep ebabebefief tate te pete g
+92; Maneu) Suck 4 -|\4)1| -| pated Pees Hef} loll Wp seh Wopmeal a -ledlad                  |
+59\\ 43 Aller  |  bk de SIP Seeeent ia  ripnctti HCG. | He} ete} | ote feted ef e[ ey. |
+aca  Serre tr. | ast. Aecotoid 21H) J of eh LL eteteL tsp ede fete
+J Nich. holla.  Sc offs] -f- | 4. He | |   : ie    |     |   |,       |      }
+g    |  1  Seaecn |  |  | (92,| Mastin Hadly $4 -|-\2 -| - ian hed el dw betel OI
+ul IZ  |    |    oe ee |    |   | | Pe fey, Wladtoxr   |.  “ft-o] tak st ae | [el
+fl) Wick. Jef ..'\s4 28 -\ 4  Reis, be  Beeeil     |
+' “a “oulaal Pee rey |      Redtad 40\Achr3 Jamil? Doafkanese. |
+ Senjawissst 94d | elf fe |     cee   WA       | al    “   See      Vf
+lean.  i,  Meee ec eneeae lil Someatey 414 )) 2-1) pebble beled al
+err Hala tel LEP. Lf deers Paneresar ne:  felled Ld |
+nt |   4   y G  .  I, Dacsnin nn 7h Abe     |    |     Orb   He ald  C ff, r PAVE ye,? »  Jat : |
+@| Sopdet |  a  speRaaal    et,  Bd Syn Lcd. / oes Bull
+é  ;               a ee eg                                             }
+Sinan Bearofathe|-|+| |] 4+) -f "ABE     ha        Coleneh ofacrsaye \kd| AP \ Chuckinar Yep Nareed
+i   |  |  |             eo ui a P         |   i a7
+|      TOE | ere. ||     area     dba
+    Ca, | sh e| -fo} eile] «Il Spel. Wg ls fist  or fie ih  |        ee a Lal AG | ee |e Oe On | S's
+i      |    |              |  {feet Lad | alg. bail
+nt

--- a/dataset/validation/_md/markitdownnet/ICDAR/cTDaR_t00016.md
+++ b/dataset/validation/_md/markitdownnet/ICDAR/cTDaR_t00016.md
@@ -1,0 +1,44 @@
+|               ‘etc <i —       a              |
+|    / NOMIN  | cine ees rm fee ee   y Prun py att Me
+|             :     A | ottindantine     fie] Stseee | ems angi mg    Spit, Minaye Searle, 2 Wei aga Bc ern
+yoo eel eee]   Dee ee ate fs Maes hal te os
+I  |         HE elf] 8 [2/é|/s] é SS |              Low is ohana casa tae Pharlled Fenda Otane Zenih
+pee AEE E||& ial: i : ail ‘s/E) a) al =a       Com Clapir   | Oachenye Satin, C2 pt oharja. Semluch, Desctigy |
+|        |    eanfla. ashok  te   PALE  | IMENA  Wetiat  ; (ie.   TTTLT te
+   /         | 4  oe   ,         hs | |      \EiPRIDOV   |B) a |g ae s || 5 Bi§ :    a         OES
+eas Fiageh | - PraevOReee  rhe | |    |      VEL IS! S Bla lal i 2 | a st oretal tee  leis
+v2      |       .  | ros Weal ited ete, |e     ils     | q a  Ef east eal a Pi 8 Xe S Ble o/s 3 g  les
+          SV ep:  oth   |.    ,               |  od ef Bod al } myo    — IN ere | BIR IW > A| (812 B| (eS
+| Ales tafmdcy |. Ce meh ak:    ee a Meee es Huge
+:   li      Jeff effi ebefe} ed      i               ba   |   1 a i ae lan Waals
+eta atl Maa     Bent tay
+      ie aia   Fai  =a 0          g  Pde yd a  |   i.   WEA:  9%                  Br   Ch. |               is  |
+|     G\ hal. FeQetled dlaval ||.      |      aia hs Bis. atk | | el ahogl |         i 4
+A          Had      |              |       t2\| Phila:         ah fl oe yal os               |
+Awa | i Oa         |     Wye Chil, Rrech         | ila  Hf SPs            ae   |
+c cameo nnn TTT, Wee ee asl  balal salelat (alate | |
+|      _———     |              Alii WO] Fegehe’ Bebeen PA miles bused gh ae oAly\ | CE 74 9) -
+oo  |      (ma. ast lone 1-1-1 al de  Lt      Weal ack    | ALOR. | % Al    | 4 2117 big  thes fal be   |
+} |      AbapanePAT PAGAL la) il ag | ars eg | 4 cou blaalilal.| dali
+Bl ga nesrseptcotpanipnl Perea ‘pane ias yf
+Hi  i}                   BY |     “ne   4   1,                      \             fa.6    4 #2     .   |     }    he    .     Zoey   i
+|          Deki ried sped et sacaal lipamog b 444-|elslolaalel el atta
+|  pate  y,   4   | Abell aed   ll BATE | | Mpg |  ae bi ass Bb’
+         iT     S  ‘   WL each S63   eae | eal  r    Taal y   - Gk Vad ail       ‘Bug
+        At?    eg  A   AY [2 7   A UZ,   | ‘    Vauk .. jr 192 sire ies Bye 9.    34  s   |
+| ee ee TT lh (Re) ae Ho.  A ea tA sili onl 7. «|    Ms -
+|          |    bbled te) kato ele    ye. | NG        a2 e5 4 #004 &    14 | 0424 24 te. |
+     :     |         | M    tH  is    ;       |   f  di Suxiefinect.  uals i air a) a ‘
+|   f        eg sh    it lef  | SH | 2) A\1928 05) 74 481 7.     r
+|            |     beg het L   AGIA J  OT |: ce dacaees  a bn  ’  ae. we 4 14 4 74     |
+i          |      y    YE ey A Wopetan, Hal and          )   4 | G94 o9.Me gl 7        eg ow
+|           |  |   u4 Ze  M1 TAD Zale ha Al 4  |        Sabie! Bede;    9 Os HE a | gat ated     '
+t                                 1                Ae  aah                                          2      ai Go bes        oe)                        |         7
+|    |        ae (od 2u3 Las      (ad a sedges)
+|        | |          SD i bee Gimsiy) 22 || danas 9) 2 3         !
+7           |     |     tT eee ga cl sll ol ig    -| 2
+       W)    }    Wie heh gy 4 “ bias) 2   /
+Vee        ‘                      yy ma‘     |      one a   3     ..   Aq  f  i
+on |                                |       I      |             [SS         at    a    -           .
+ae               , |   |  |    | |    | |      (ame A 2s Whe  a       7     ;
+ny ee bes | {   ¢   |   | |    i    ‘   - | PH Ey, 394 .  I oe pt   at

--- a/dataset/validation/_md/markitdownnet/ICDAR/cTDaR_t00080.md
+++ b/dataset/validation/_md/markitdownnet/ICDAR/cTDaR_t00080.md
@@ -1,0 +1,56 @@
+— 7   .      °     scons  i         oe                 "sd
+;       :            *      ey,      ;                 =      ‘    :                 Ae    Re    A
+ii A Mert,  : = Cciles LAY JOA sociale Teas ereshack A toy A¢¥.
+satis          3     Pee                          ae.
+Tuy     p Te  jaf                          ¥                  ee ———                        ;
+Y ie taal fo [a
+Te     i         ‘             sales Kh :             Ag ATI   ,        g thi  o    —<— FF
+i.        aS                            4                                Wf   .     PCLAG   i
+Wedge 1  i ee
+POV! auaataa A Gogh CMinpir 597, ME taf Ors FE      Ae
+ii { Bry. Seca rnut as   Moy Siben ttf,    PY 4 4 $     3 ry PY     , fi    SY fries, hy bs
+bs We.         I"                  5        ate  th Ce    sie ag gay, eo   g   he         e /
+fpr ©           f.      /          Pig. he fe      ibd Sie
+&          or 5 gE RAGE CIM J     m   A Ree oe     : a  ~         .j ’     oe  at
+feo! Pay FZ) gerd Oud | ee Care           Yr ee
+in| Vine, srk     4A AP p 7 pe 7 oy a         ALeones ie a      ¥ y/ Selly fled)  |
+Rave ——— | Wc Ginbsor | 9. 7          ay li,
+femme |         1 oe *             LF PWV GY Ay                 —
+20 /Von                Ahn? LIOR,    WA   itp     Lid i *                    |
+iti ee                                 Prd fdl iro                   _
+i     Betis SS es Se      Os      a    taf     |                  |
+aigg IS peed ad
+“Rates!    of £5    :         ae i      aF       ‘doa shy           .         anges     Po
+WWa~  wt loys  Mh Aur 7!    by th.     Y,     , yee te  7 i
+jg eee fy ef                      oh           |                Uy
+onl  bro. | BIL 77   Mei; ey ey BY  £ S  fi    >    la    | 4 -  Y]      |
+Megastore a A heey       bade ae          z
+PT                 2 gee To                  f
+Tim Yoong. | Bay Mitte ag inn |p, ape
+1M         of,  OD Mifyis pu Stee      ie Eo  of:  533  { if     ph, i
+LAO acute aa                                    j            Phd      tL a
+7          ea                 LbOF | Lay,              ee        7
+ae °                                     p-              eee aoe He               ae
+Ieee Cece!   x    is     bf dee  f  7:  om  Q*   Pa                    y
+ie  :         phy:  fe y    hE: i  ‘ae f   0,4 Yar    Sig        4  Lf          q
+(fies    3 ye Z 7  N,  Lo, Snaritt focy Y J -| Saaatagly,   :  ,       -   A     OS       — j
+Mea «| fg    %                      }   4      ‘                                  *   ‘ f
+sl mil AE: pb to                       :                     A
+7  Ben usin      = Yasar          pnt Ly hue           1D.
+Ran aie
+of          ‘            f            -        t   4                      :       et
+ae                 at Toe         =                    oy
+4          Jp f*     ,  be he     je   nm Boer          Is i?  .  up
+-—          ,   Mi fSbad BS  7 Ate Be   ih      :           ————
+4 ey          hor                     Sou fre! | Pb allgriagy A
+Yr ROO)                      + | oesnanypacy.                    Lo
+|     id   fi i,                    ae             ;                                          x  4 ¥
+8 Cuoll     2 |S Az fund     =    |         |      “i
+Gy Foe LT ee | Pre initel -  y
+je we) a    nto d    Q  WIE SSS       Meg ( fF.   Ps      neck  paecieeey | ;
+| etfs     :          ahr  of    OB &                f hen     Ar            oe       at: a a
+4h       (7   A                         4     A                a»   O07    Bees   t
+|              D. Rndtficart loafer fons  :    ae | ES en
+       Of /       Se ae         a     . pS ae
+;       *       ev: flaws ee           ;     a           ce       5%   5    ce "ae = it
+We eee ae ee ee        ae eee Se

--- a/dataset/validation/_md/markitdownnet/MARMOT/10.1.1.1.2006_3.md
+++ b/dataset/validation/_md/markitdownnet/MARMOT/10.1.1.1.2006_3.md
@@ -1,0 +1,101 @@
+09                           these consume 0,99 CPU. That is, task3- misses
+
+ra            praia        deadlines and the inverted pendulum! falls down, This
+
+og Ltr                     c                                explains the fact thatthe cost function in Figure 2 goes
+
+.                                to infinite. Note that under RM, the task is not
+
+Bod                               schedulable
+
+i                                + EDP: EDF is « dynamic alorihm in open bop
+
+§                                           Which assigns priorities to tasks according to their
+
+i,                                   Beavis dedine, Une BG’ holler te
+
+schedulabiity condition is given by U = 1. For our
+
+4                                         simulations, since U <1, the task set is schedulable
+
+and the three pendulums can be controlled as it can be
+
+1                                                           seen in Figure 2: the accumulated cost reaches a finite
+
+a a oe       value, which means that the deviation caused by each
+
+icici al ak aed                  perturbation thet affected each of the three pendulums
+
+could be adequately comected. ‘The performance
+
+with the difference in performance due 10 the we of sehieved by EDF is also given in Figure 2 in tems of
+
+different scheduling polices, which is the objective of our      tie coat BocHonsreadting a valus oF W2754 at tho
+simulations.                                                                   completion of the evaluation interval
+
+‘The perfomance of each pendulum is obtained by the
+
+following cost fmetion J, which measures the enor ¢,of 4 LER: LEF is a dynamie scheduling algorithm in
+
+the pendulum weighted with time ¢                   closed-loop, which adjusts the schedule based on
+
+= fre2enae                continuous feedback of each control loop. Under this
+vin= |ehom                         scheduler, inthe simulation we ebain thatthe thee
+Note that 1 sets the duration of the evaluation period,        inverted pendulums can be perfectly controlled. As it
+
+‘hich typically should go fen the’ perturbation sirival      can be seen in Figure 2 the cost function of LEF goes
+
+fine (0m the integral) wo the setling tine As higher     blow the cost function of EDF, meaning that for this
+
+values the cost function gets, the worst the control palticular simple simulation set-up, LEF performs
+performance (because major deviations occur or because it      better that EDP. Note that the final cost of LEF is
+
+fakes more time forthe inverted pendulum to recover from          0.2490
+
+the perturbations)
+
+C. Discussion
+B Results                                     ‘The exact cost for each one of the three pendulums
+The simulation we run Keeps the following time under each scheduling algorithm is summarized in the
+sequence: at time =O, only the control task controlling the Table 1. RM fails in controlling the thitd pendulum, EDF
+fist pendulum is released. After executing alone, at time and LEF are able to control the three pendulums, However
+
+12. another contol task is released to control the second LEF gives the best control in terms of the cost function
+
+pendulum, Finally the third control task is released at time
+
+f4, The three controllers run in parallel until t=7. Before Tate 1, Cost forthe tac inverted pendulum under cash
+
+the release time of each control task, the corresponding                 different scheduling policy
+
+pendulum isin equilibrium, At release time of each control              ———
+
+fask, the pendulum suffers a perturbation (of equal      Scheduling Jy Sp
+
+magnitude for each pendulum). This simulation pattern is          RM 00033009308
+
+repeated for different scheduling algorithm: RM, EDF and          EDF 0033. 00930 0.1769
+
+LEF. During each experiment, the cost funtion presented          LEF 000330812 _o.1645
+
+earlier and the resulting schedule are recorded. The cost
+
+function evaluation period goes from the beginning of each This results shows that scheduling polices that take
+
+simulation, =0, to the simulation completion, at t=7. For advantage of the application dynamics and are able to
+
+cach scheduling policy, the results we obtained are agjust the schedule accordingly ean provide, in. some
+summarized inthe following:                   Specific scenarios, better performance in terms of the
+application (control performance in our case).
+
++ RM: RMisastatic scheduling algorithm in open loop, For opertoop scheduling approaches we identified (see
+which assigns priorities to tasks according to their Section 1) three main negative aspects: low real CPU
+request rates. The cost function values for the three utilization, the lack of feedback mechanism and poor
+pendulums are shown in the Figure 2 (note that Figure gdaptability to the application dynamics. Our. strategy
+2 shows the accumulated cost function, 2, during the optimizes CPU utilization in the sense that control tasks
+evaluation period for each scheduling policy). Under are executed only when they are required. That i, they are
+RM the schedulability condition for our experiment is executed when the controlled plants suffer perturbations.
+given by U < 0.78, Taking into account that task Otherwise, they execute with the slowest possible rate in
+execution time is 4ms, until 4, the processor order to give room to other tasks with higher priorities. In
+utilization is 0.71 and the control performance is good. addition, our approach is based on the idea of feedback,
+From t4, the tree contol tasks run in parallel and which offers the possibilty of taking at run time the

--- a/dataset/validation/_md/markitdownnet/MARMOT/10.1.1.1.2013_63.md
+++ b/dataset/validation/_md/markitdownnet/MARMOT/10.1.1.1.2013_63.md
@@ -1,0 +1,38 @@
+4s
+Table 1—Activity, employment, and unemployment rates forages 15-64, by sex and
+urban/rural location, 1990-95
+Cs
+Rate             1990 1991    199219931994 1995
+Activity rate (15-64)
+Urban Male        no   108   69.8   108   105   699
+Female        24    203    19.1    203    202    195
+Total         473    457    444    457    454    448
+Rural Male      782   168   163   163   76.1   163
+Female                 347        293        261        240        254        230
+Total         564    530    50.8    50.2    510    497
+Total Male      753   749   2   7   BS   B3
+Female                 290        252        2.8        23        230        214
+Total          52.    49.6    478    48.1    484    474
+Employment rate (15-64)**
+Urban Male        670   653   647   649   649   646
+Female        168    154    143    146    146    14.1
+Total         42.1    405    395    399    308    304
+Rural Male      45   na   18   109   107   106
+Female        316    262    28    195    204    181
+Total         330    493    469    453    458    443
+Total Male      110  69.1   68.5  68.1   68.0  678
+Female        247    aul    189    172    117    162
+Total         479    452    434    428    43.0    420
+Unemployment Rate (15-64)**
+Urban Male         69    1    13    84    19    16
+Female        248    244    249    279    280    276
+Total         Ma    14    na    127    124    119
+Rural Male       47   57   59   10   A   1s
+Female        9.0    108    125    187    19.6    214
+Total         60    mM    16    98    10.1    107
+Total Male      57   66   63   16   1s   1s
+Female        147    159    173    27    2.1    241
+Total         82    89    om    i    Te    113
+Jouce:CAPMAS,LFSS,——SSSCSCSSSSSSSSSSSSS
+Notes: Activity rate = labor force/population x 100 percent; employment rate = employment/population x
+100 percent; unemployment rate = unemployment/labor force x 100 percent

--- a/dataset/validation/_md/markitdownnet/MARMOT/10.1.1.1.2013_64.md
+++ b/dataset/validation/_md/markitdownnet/MARMOT/10.1.1.1.2013_64.md
@@ -1,0 +1,21 @@
+46
+Table 2—Labor force participation rates compared, ages 15 —64
+Sg
+_ SSeS 99S SCSCOSIOT
+Wale han SSSC~SSSSC~—~OCSSSC
+Rural                              792                              76.3                              154
+Female Urban                   293                    195                   262
+Rural                    539                    23.0                    173
+‘Table 3—Unemployment rate, by sex, education, and region, economically active
+population aged 15 ~64
+,_.-. TRS 19—S—S—~—~—~—~“—siES TTS
+With search              With search            Without search
+“Tran Runt Tos! Urban Run Tot “Urban Rural Total
+Mie
+Below secondary      13, 04 07 5402033    M3300 47
+Secondary andabove 14126001893. «12.7s9 130169147
+Total          16° 75 78 84 S54 68 101-7788
+Females
+Below secondary     4103 «0.70 «9816S 7S 1732-202
+Secondary and above 30.9 $7.7 40.0232 «405 8S 53.2384
+Total          276 214 24.0 2012302139732.

--- a/dataset/validation/_md/markitdownnet/MARMOT/10.1.1.1.2014_4.md
+++ b/dataset/validation/_md/markitdownnet/MARMOT/10.1.1.1.2014_4.md
@@ -1,0 +1,36 @@
+3. Ifa change is declared, then (a) the point pat time remember all the data points. Instead, if we can make the
+L-changeResetWindow is marked as a change point, system forget older points, we should be able to detect out-
+(b) all points after it are unmarked (they are not out —_Tiers/change points better.
+liets anymore), and (¢) the model estimation is stated
+afresh from p,.
+Table 1. Parameters for deciding outlicrsichanges. Pa
+rameters with * are user-provided
+Tae          |
+Sina | 2 tat a ea                 a                          is
+sntrortrait | enim ny i tr                    W
+—_          Scigcwsencame "="                   S
+een mare soutien amd dens om f                   Figure 1. Effect of older points in RLS-based
+ey          Re Date enuccemone b            outlier/change point detection. (a) saw-tooth
+___ | Sesto ac ofertas                  data stream. (b) slopes of the line segments
+crenimseniot | LeRoi cr cn roe       in the sawtooth. (c) slope estimate using
+crmrovrdeds | ute miner of pon wat the nena          RLS. (d) slope estimate using a moving win-
+mecefleatececimet cries | dow of alze5,
+ea          Foeiee See ae Tee            One approach to forget older points is to have a moving
+oo         Sear ece oc EEA       ‘model over this window. At the same time, we would like
+3.2.1 Using Forward-Backward RLS
+‘One method to achieve this would be to derive a backward
+3.1 The Naive Approach                                  recursion and altemately use the forward and backward re-
+In this approach the RLS algorithm is used to compute sions as follows,” Suppose the current window spans
+the model parameters over all the data seen so far (unre-_‘{lts-- fw) When a new data point comes in at fy 41, we
+Geeaciae)                                                      use the forward recursion (equations 7-9) to derive a model
+Inivally (forthe fist few points) this approach may be "the points in [fs..» fy ty 11) Then, we use the back-
+succesfl in detecting outicrlchonge pots, As more Ward ecursion to remove the effets ofthe point at and
+points come in, RLS estimates the model parameters con- ‘its get a model forthe points in [fzy...«fovfust
+In what follows, we derive the backward recursion for
+sidering all the points seen so far, and thus it gives equal                      5
+‘weight to all the points in the unrestricted window, Asa RLS. Suppose we have Ania and Pia over certain data S,
+result, the changes in the dynamics of the system may be W#eTE
+hhidden by the dominance of the older points. Figure 3.1 il-                               a
+lustrates this phenomenon. As a result RLS by itselfis not       Pua       BT)                 10
+sdequne, Te pblem w de tothe fet dat RLS esto           Hey ane)                      an
+4

--- a/dataset/validation/_md/markitdownnet/PUBTABLES/PMC1064078_table_0.md
+++ b/dataset/validation/_md/markitdownnet/PUBTABLES/PMC1064078_table_0.md
@@ -1,0 +1,10 @@
+Cases and controls in Carolina Breast Cancer Study (CBCS) analytic datasets by race
+Atican-American                          write
+Anayic dataset                          Main exposure                 Cases(%s} Controls 6) Cases (8) Contos (8)
+BCS, entre                            Beth order                     385 (1000) $92(1000) 526(1000) 488 (100.0)
+(©BCS, bom 1948 or later                                          191 (59.1) 198407) 235 (447) 181 (3085)
+Maternal age dataset        Bithorder, Matemal age —-«107(81.)116(349) 173 (829) 121 (26.4)
+Paterna age dataset        Paternal age         95 (284) 100(90.1) 171 (928) 118.(25.8)
+(©BCS, NC bom 1949 o ater                   90/206) 96 (289) 112 (218) 85 (18.6)
+Birthweight fll datasot                Bithweight                    861257) 89268) 110209) 7817.0)
+Binhweight, resticted dataset        Bithweight                 49(146) 970013) 98(186) 63188)

--- a/dataset/validation/_md/markitdownnet/PUBTABLES/PMC1064078_table_2.md
+++ b/dataset/validation/_md/markitdownnet/PUBTABLES/PMC1064078_table_2.md
@@ -1,0 +1,19 @@
+Birthweight slistbutions and odd alos for breast cance in Aican-Amercan and white women combined
+Minnay ated OR      Ful aja OR
+
+Canes Conte ——OR" «SHC Gatee Canto ORY 95H
+Ful bthwight dteoot  a=08 | n=t07     nate nator
+Lower tree    7  7  09 0618 72  10 oer
+Conta te   20  st at  © st Ret
+Upper tre    8s  86  07 o&t2 80  807 ona
+Mean 8D (@)      anon #850
+Median)       sea
+Range ()      toat—4ea
+Resticted dataset   antay—— n=t00     nava nnor
+Lower trae    se  “  os os17 88  4 10 os09
+Conta te   ae  a fet  ” a Ret
+Upper tre    0  25  10 0s21 98  2508 oat
+Mean #80 (@)      ano. a2
+Median ()       eae
+Rage)      2081-4621
+‘body mass index >25 kg/m?, <Tertiles are race specific with cutpoints denved from controls. White women: <3062 g, 3062-3458 g, >3458 g;

--- a/dataset/validation/_md/markitdownnet/PUBTABLES/PMC1064078_table_3.md
+++ b/dataset/validation/_md/markitdownnet/PUBTABLES/PMC1064078_table_3.md
@@ -1,0 +1,13 @@
+Birhweiht strbutons and os tos for breast cancer among Aicar-Ameian andwhte women byece
+en            rao
+Gan Gatch OF HG Gam Ganah OF HG Gm Gomes OF WHO Caw Goma OF HONG
+Comune 8   oe  am  7 MM
+messes         ome
+sn    on       ne
+oe                        4734
+sioess0) sates      cae
+i
+sn    oe       ne
+nents    ai       a
+ay ee en en SE
+ea a ae oe rs acre ae, we hi ee

--- a/dataset/validation/_md/markitdownnet/PUBTABLES/PMC1064078_table_4.md
+++ b/dataset/validation/_md/markitdownnet/PUBTABLES/PMC1064078_table_4.md
@@ -1,0 +1,21 @@
+Parental age distributions and odds ratios for breast cancer among African-American and white women combined
+Minimal acusted OR*                                  Ful adjusted OR®
+case              Conti OR-—«8BHC!_—Case—=—Contol-—«OR—— BHI
+Maternal age ears      n= 260    n= 296             n=263 =a
+1948            at      a1     18 0934 90     2 18 og-a5
+19-22)                           st                  80            Ret                         4              7 Rel
+29-27            a      49    20 1880 as     495 20-80
+28-44           m      n    25 16-40 100     830182
+Mean # SD        2estes 252467
+Median                                28                  23
+Range                              17-48             15-49
+Paternal age ears      n= 206    na2ie             n=251 n= 200
+15-22            39      38     10 0648 38     318 Ban
+29-27 (ro)                          73                  0            Ret                         ©              Ret
+29-34            27      o     19 06-21 a3     e212 aren
+95-56            o      4s     16 0926 61     415 oraz
+Moan # 80        sorz1) 298278)
+Median                                29                  28
+Range                              17-83             15-86
+Soetatos or 1) sjased GR powsahocl cam £680,000 hd ith crdeAdstoralcovattcs or aly agusted OR aa boy ass index
+CORES 25: UY BRINE Ses, Beaies Ole INCRE emmy, Riel ONT

--- a/dataset/validation/_md/markitdownnet/PUBTABLES/PMC1064078_table_5.md
+++ b/dataset/validation/_md/markitdownnet/PUBTABLES/PMC1064078_table_5.md
@@ -1,0 +1,15 @@
+Parental age distributions and odd ratios for breast cancer among African-American and white women by race
+Moimayaustes OR                 Fal agurted OR
+Cue Contol OR 9B5CI Case _——Contol- OR BWI Cass Conteh OR 9BHCI Case Coaval OR 95M CI
+yews"   i   =        a   es        eae       SUTURE:
+15-18  10  7 2 0955 12  4 41 0529 18 15 27 10-70 12440 04-87
+wea   18   2 Ret     29   47 Re    789 Ret     a 4k Ret
+2-27   28  2 19 094s 88  242 21-89 27 2824 10-84 88208 23-08
+Mein#8D 286279 255270      vests 249269
+Medan   26   2        26   2
+Petoaiage = 95 n= 100       nai pate       nao n= 94      ne te2 nena
+‘yeu
+15-22   16  15 14 06-99 29  2 07 0345 18 27 10S 21814 05-28
+an   2   20 Rt     s   40 Rt    2 Ret     98 Ret
+Mon280 90926 204280     msz68 90269
+Saeco snd Geter sAdecorlcovrates or fly sduted OR ada body macs index 928 ln Nowsehod income S8S0,0, bh Oder ane maternal spe

--- a/dataset/validation/_md/markitdownnet/PUBTABLES/PMC1064078_table_6.md
+++ b/dataset/validation/_md/markitdownnet/PUBTABLES/PMC1064078_table_6.md
@@ -1,0 +1,7 @@
+Bir order stb and odds rato fr beast cancer among whit and Atean-Ameriean women by ace
+a et           raya
+Goat WAG Ge tot WHE “Gen Gas OF ONG Ge Gm RNG
+mona a8     wae
+Ty
+pS
+“ene dence, ied rp ati rd hg rena "loa pave a aie OR on Rg,

--- a/dataset/validation/_md/markitdownnet/PUBTABLES/PMC1064082_table_0.md
+++ b/dataset/validation/_md/markitdownnet/PUBTABLES/PMC1064082_table_0.md
@@ -1,0 +1,3 @@
+Imunchtochemy ndings                  alate mRNA epesson                P
+000                     >2000
+Hah erosion       3           "           <oao

--- a/dataset/validation/_md/markitdownnet/PUBTABLES/PMC1064082_table_1.md
+++ b/dataset/validation/_md/markitdownnet/PUBTABLES/PMC1064082_table_1.md
@@ -1,0 +1,26 @@
+‘The relationship between lysophosphatidic acid receptor 2 (LPA2) expression and clinical/pathological factor
+_LPA2 expression        Low (36)            High (4s)            P
+Age (ears)
+<50                                20 (56%)                              16 (35)                             0.042
+250                                16 (4406)                             3267)
+Tumour size
+11 (200m)         16 (4490)            17 (3550)            Ns
+T2E20emt0<60em) 18 (50%)            25 (82%)
+73 P80em)                       2 (63)                                5 (13%)
+Nuclear grade
+1              5 (14%)            5 (10%)            Ns
+"                            24 (67%)                       31 (0550)
+u                                   7 (198%)                               12 (2558)
+Menopausal status
+Promenopausal                  21 (58%)                          17 (9550)                          0.097
+Postmenopausal               15 (4208)                       31 (6598)
+Costragen receptor status
+Negative                           10 (559)                             27 (869%)                             Ns
+Positive                      8 (45%)                         21 (4498)
+Nodal metastasie
+Nogative                      12(83%6)                       21 (4480)                       Ns
+Positive                            24 (6796)                             27 (865%)
+Distant metastasis
+Ngati                      27 (75%)                       41 (659%)                        Ns
+Prsiive                            9 (25%)                               a)
+~ Numibers in parentheses indicate percentages inthe same expression pattem, NS, not significant,

--- a/dataset/validation/_md/markitdownnet/SROIE2019/X00016469670.md
+++ b/dataset/validation/_md/markitdownnet/SROIE2019/X00016469670.md
@@ -1,0 +1,28 @@
+tan chay yee
+88 COPY **#
+## OJC MARKETING SDN BHD
+ROC NO: 538358-H
+NO 2 & 4, JALAN BAYU 4,
+BANDAR SERI ALAM,
+81750 MASAI, JOHOR
+Tel:07-388 2218 Fax:07-388 8218
+Email: ng@ojegroup.com
+# TAX INVOICE
+"jfvelee No” peGAOSoIEs
+Date       + 15/01/2019 11:05:16 AM
+Cashier     : NG CHUAN MIN
+Sales Persor : FATIN
+Bill To      : THE PEAK QUARRY WORKS
+Address     bs
+Description. Oty. Price Amount
+000000111            1 193,00    193.00 SR
+## KINGS SAFETY SHOES KWD 805
+“OT Fetal Beclide tT T9560
+Total GST @6%:          0.00
+Total Inclusive GST:        193.00
+sippeaciaa Round Amtt 550.00...
+TOTAL:        193,00
+9000000000004 31.8
+Approval Code:000           VJ  a
+Goods Sold Are Not Returnable & Refundable
+***4Thank You. Please Come Again.****

--- a/dataset/validation/_md/markitdownnet/SROIE2019/X00016469671.md
+++ b/dataset/validation/_md/markitdownnet/SROIE2019/X00016469671.md
@@ -1,0 +1,28 @@
+tan chay yee
+## OJC MARKETING SDN BHD
+ROC NO: 538358-H
+NO 2 & 4, JALAN BAYU 4,
+BANDAR SERI ALAM,
+
+81750 MASAI, JOHOR
+Tel:07-388 2218 Fax:07-388 8218
+Email: ng@ojegroup.com
+Cash Bill
+“invoice No" PEGI 03085
+
+Date         02/01/2019 2:47:14 PM
+Cashier      : RHYS TAN
+Sales Persor : FATIN
+2 Deseription | Qty. Price Amount
+000000111            1 170,00 = 170.00
+KINGS SAFETY        ‘POO4
+# SHOES KWD 805
+“Gey T Total Tem Biscount! G60
+Total Amount:       170.00
+cecseeseneeeeen ROUNd Amt. 0.00
+TOTAL:     170.00
+VISA CARD          170.00
+# 2090000000043 18
+Approval Code:123            I30  U0
+Goods Sold Are Not Returnable & Refundable
+“Thank You. Please Come Again.****

--- a/dataset/validation/_md/markitdownnet/SROIE2019/X51005200931.md
+++ b/dataset/validation/_md/markitdownnet/SROIE2019/X51005200931.md
@@ -1,0 +1,41 @@
+hong a
+PERNIAGAAN ZHENG HU!
+JMO825986-V
+NO.S8 JALAN PERMAS 96
+## BANDAR BARU PERMAS JAYA
+# 81750 JOHOR BAHRU
+TEL :07-386 7524 FAX: 07-386 3794
+GST NO: 0oo80058e824
+# SIMPLIFIED TAX INVOICE
+GOGIANT ENGINEERING (i) SDN BHD       ~
+Recelati# CS00082258
+‘Salesperson,                     Date. 09/02/2078
+Cashier: USER                      Time: 08:32:00
+nr oer
+tem                  Qty RSP Amount
+6783               Woy 5 380 HBL
+# SR CERAMIC CAP
+2084               $84 30 380 © 114.00                                   .
+SR: SISTEEL 1/2" STREET ELBOW
+1760                GA 4 85.00 86.00
+SR: 24MIN STARWELD RED HEAD TUNGSTEN ROD
+3496                 44 3 B00 99.00
+SR: ESICUT 4" CUTTING DISC (4BOX)-50PCS
+2460                 GA 2 43.00 -86.0¢
+SR: WELDRO PICKLING GEL 1K
+9428                 Ge 4 1900 40.0c
+SR: 13.5" WELDING GLOVE- GREEN (@3}
+# TOT GT BE
+(Excluded GST) Sub Total (RM)        411.50
+Discount (RM)          ooo                °
+Total GST (RM)         24.69
+Rounding (RM) :       0.0%
+Total (RM): 436.20
+GASH : 436.20
+Ghange (RM) :       0.00
+# GST SUMMARY
+_TaxGode %@ Amount GST.
+SR               6         417.50       24.69
+Tg tal TOR
+GOONS SOLD ARE NOT RETURNABLE,
+THANK YOU.                                .

--- a/dataset/validation/_md/markitdownnet/SROIE2019/X51005230605.md
+++ b/dataset/validation/_md/markitdownnet/SROIE2019/X51005230605.md
@@ -1,0 +1,25 @@
+## PETRON BKT LANJAN SB
+# ALSERKAM ENTERPRISE
+Tel: 03-6156 8757 Co No: 001083069-M
+KM 456.4 BKT LANJAN UTARA,
+L/RAYA UTARA SELATAN,SG BULOH
+# 47000 SUNGAI BUL
+GST ID No: 001210736640
+# TAX INVOICE
+TAX INVOICE NO: 19729058
+POS: 4
+Store No.: 129077              Babu
+01/02/2018 4:43:17 PM
+A 2 double ,mint te         3.00
+& 1 sandwich venil]             1,90
+GST RM:                       0.28
+Total RM inc.G3T:            4.90
+Cash                        5.00
+Change                       0.10
+GST Summary    Amount (RM)    Tax (RM)
+A=6.00%                 4,62                       0.28
+A    ITAL INCLUDES 6.00% GST
+Use 3000 Petron Miles
+points to pay for
+RM45 Fuel
+*            F          Reet            H


### PR DESCRIPTION
## Summary
- generate Markdown for canonical TXT inputs using both markitdown and markitdownnet engines
- run mdcompare benchmark with markitdown baseline and record results in JSON/HTML/summary outputs

## Testing
- `~/.dotnet/dotnet run --project tools/MarkItDownNet.Cli -- mdgen --txt-dir dataset/validation/_ocr/pytesseract-cli --out-dir dataset/validation/_md --engines markitdown,markitdownnet --python-exe python3`
- `~/.dotnet/dotnet run --project tools/MarkItDownNet.Cli -- mdcompare --md-dir dataset/validation/_md --baseline markitdown --out-json artifacts/mdbench/bench-md.json --out-html artifacts/mdbench/bench-md.html --summary-md artifacts/mdbench/summary-md.md`


------
https://chatgpt.com/codex/tasks/task_e_68a7bd720e588325bcbabd081d3a000f