### PR TITLE
Add RapidTableNet for table structure recognition

### DIFF
--- a/dataset/training/busta_paga_internet.jpeg.rapidtable.json
+++ b/dataset/training/busta_paga_internet.jpeg.rapidtable.json
@@ -1,0 +1,16 @@
+{
+  "layout_time_ms": 401.6298,
+  "tables": [
+    {
+      "box": [
+        2.3094149,
+        0,
+        627.7778,
+        779.5563
+      ],
+      "recognition_time_ms": 413.8335,
+      "cell_count": 72,
+      "token_count": 259
+    }
+  ]
+}

--- a/dataset/training/sample_invoice.jpg.rapidtable.json
+++ b/dataset/training/sample_invoice.jpg.rapidtable.json
@@ -1,0 +1,16 @@
+{
+  "layout_time_ms": 203.9631,
+  "tables": [
+    {
+      "box": [
+        58.271088,
+        312.3186,
+        1195.3634,
+        560.45557
+      ],
+      "recognition_time_ms": 274.8954,
+      "cell_count": 16,
+      "token_count": 28
+    }
+  ]
+}

--- a/dataset/training/sample_invoice.png.rapidtable.json
+++ b/dataset/training/sample_invoice.png.rapidtable.json
@@ -1,0 +1,16 @@
+{
+  "layout_time_ms": 121.8675,
+  "tables": [
+    {
+      "box": [
+        58.31236,
+        312.28497,
+        1195.3623,
+        560.4444
+      ],
+      "recognition_time_ms": 149.0084,
+      "cell_count": 16,
+      "token_count": 28
+    }
+  ]
+}

--- a/docs/rapidtable_training_report.md
+++ b/docs/rapidtable_training_report.md
@@ -1,0 +1,44 @@
+# RapidTableNet training dataset analysis
+
+Model: SlanetPlus
+
+## Summary
+
+| Image | Tables | Layout ms |
+| --- | --- | --- |
+| busta_paga_internet.jpeg | 1 | 401.6 |
+| sample_invoice.jpg | 1 | 204.0 |
+| sample_invoice.png | 1 | 121.9 |
+
+## Detailed results
+
+### busta_paga_internet.jpeg
+Layout time: 401.6 ms
+Detected tables: 1
+
+| Table | Bounding Box [x1,y1,x2,y2] | Recognition ms | Cells | Tokens |
+| --- | --- | --- | --- | --- |
+| 1 | [2,0,628,780] | 413.8 | 72 | 259 |
+
+Output file: `dataset/training/busta_paga_internet.jpeg.rapidtable.json`
+
+### sample_invoice.jpg
+Layout time: 204.0 ms
+Detected tables: 1
+
+| Table | Bounding Box [x1,y1,x2,y2] | Recognition ms | Cells | Tokens |
+| --- | --- | --- | --- | --- |
+| 1 | [58,312,1195,560] | 274.9 | 16 | 28 |
+
+Output file: `dataset/training/sample_invoice.jpg.rapidtable.json`
+
+### sample_invoice.png
+Layout time: 121.9 ms
+Detected tables: 1
+
+| Table | Bounding Box [x1,y1,x2,y2] | Recognition ms | Cells | Tokens |
+| --- | --- | --- | --- | --- |
+| 1 | [58,312,1195,560] | 149.0 | 16 | 28 |
+
+Output file: `dataset/training/sample_invoice.png.rapidtable.json`
+

--- a/src/RapidTableNet/RapidTableNet.csproj
+++ b/src/RapidTableNet/RapidTableNet.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.22.1" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntime.Managed" Version="1.22.2" />
+    <PackageReference Include="SkiaSharp" Version="3.119.0" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="models/en_ppstructure_mobile_v2.0_SLANet_infer.onnx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="models/slanet-plus.onnx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/src/RapidTableNet/TableCharacters.cs
+++ b/src/RapidTableNet/TableCharacters.cs
@@ -1,0 +1,34 @@
+namespace RapidTableNet;
+
+internal static class TableCharacters
+{
+    internal static string[] Get(TableModel model) => model switch
+    {
+        TableModel.SlanetPlus => SlanetPlus,
+        TableModel.PpStructureMobileV2 => PpStructure,
+        _ => SlanetPlus
+    };
+
+    private static readonly string[] SlanetPlus =
+    [
+        "<thead>", "</thead>", "<tbody>", "</tbody>", "<tr>", "</tr>", "<td", ">", "</td>",
+        " colspan=\"2\"", " colspan=\"3\"", " colspan=\"4\"", " colspan=\"5\"", " colspan=\"6\"",
+        " colspan=\"7\"", " colspan=\"8\"", " colspan=\"9\"", " colspan=\"10\"", " colspan=\"11\"",
+        " colspan=\"12\"", " colspan=\"13\"", " colspan=\"14\"", " colspan=\"15\"", " colspan=\"16\"",
+        " colspan=\"17\"", " colspan=\"18\"", " colspan=\"19\"", " colspan=\"20\"",
+        " rowspan=\"2\"", " rowspan=\"3\"", " rowspan=\"4\"", " rowspan=\"5\"", " rowspan=\"6\"",
+        " rowspan=\"7\"", " rowspan=\"8\"", " rowspan=\"9\"", " rowspan=\"10\"", " rowspan=\"11\"",
+        " rowspan=\"12\"", " rowspan=\"13\"", " rowspan=\"14\"", " rowspan=\"15\"", " rowspan=\"16\"",
+        " rowspan=\"17\"", " rowspan=\"18\"", " rowspan=\"19\"", " rowspan=\"20\"", "<td></td>"
+    ];
+
+    private static readonly string[] PpStructure =
+    [
+        "<thead>", "</thead>", "<tbody>", "</tbody>", "<tr>", "</tr>", "<td", ">", "</td>",
+        " colspan=\"2\"", " colspan=\"3\"", " colspan=\"4\"", " colspan=\"5\"", " colspan=\"6\"",
+        " colspan=\"7\"", " colspan=\"8\"", " colspan=\"9\"", " colspan=\"10\"", " colspan=\"11\"",
+        " colspan=\"12\"", " colspan=\"13\"", " colspan=\"14\"", " colspan=\"15\"", " colspan=\"16\"",
+        " colspan=\"17\"", " colspan=\"18\"", " colspan=\"19\"", " colspan=\"20\"", " rowspan=\"2\"",
+        " rowspan=\"3\""
+    ];
+}

--- a/src/RapidTableNet/TableLabelDecoder.cs
+++ b/src/RapidTableNet/TableLabelDecoder.cs
@@ -1,0 +1,87 @@
+using Microsoft.ML.OnnxRuntime.Tensors;
+
+namespace RapidTableNet;
+
+internal sealed class TableLabelDecoder
+{
+    private readonly List<string> _character;
+    private readonly Dictionary<string, int> _charToIndex;
+    private readonly int _endIdx;
+    private readonly HashSet<int> _ignored;
+    private static readonly HashSet<string> TdTokens = new(["<td>", "<td", "<td></td>"]);
+
+    public TableLabelDecoder(TableModel model)
+    {
+        var chars = TableCharacters.Get(model).ToList();
+        if (!chars.Contains("<td></td>"))
+            chars.Add("<td></td>");
+        if (chars.Contains("<td>"))
+            chars.Remove("<td>");
+
+        chars.Insert(0, "sos");
+        chars.Add("eos");
+
+        _character = chars;
+        _charToIndex = new();
+        for (int i = 0; i < chars.Count; i++)
+        {
+            _charToIndex[chars[i]] = i;
+        }
+
+        _endIdx = _charToIndex["eos"];
+        _ignored = new HashSet<int> { _charToIndex["sos"], _endIdx };
+    }
+
+    public (List<string> Structure, List<float[]>) Decode(Tensor<float> bboxPreds, Tensor<float> structProbs, float[] shape)
+    {
+        int seqLen = structProbs.Dimensions[1];
+        int classLen = structProbs.Dimensions[2];
+        var structure = new List<string>();
+        var bboxes = new List<float[]>();
+
+        for (int i = 0; i < seqLen; i++)
+        {
+            int bestIdx = 0;
+            float bestScore = float.MinValue;
+            for (int j = 0; j < classLen; j++)
+            {
+                float score = structProbs[0, i, j];
+                if (score > bestScore)
+                {
+                    bestScore = score;
+                    bestIdx = j;
+                }
+            }
+
+            if (i > 0 && bestIdx == _endIdx) break;
+            if (_ignored.Contains(bestIdx)) continue;
+
+            string text = _character[bestIdx];
+            if (TdTokens.Contains(text))
+            {
+                int boxDims = bboxPreds.Dimensions[2];
+                var box = new float[boxDims];
+                for (int k = 0; k < boxDims; k++)
+                {
+                    box[k] = bboxPreds[0, i, k];
+                }
+                BboxDecode(box, shape);
+                bboxes.Add(box);
+            }
+            structure.Add(text);
+        }
+        return (structure, bboxes);
+    }
+
+    private static void BboxDecode(float[] box, float[] shape)
+    {
+        float h = shape[0];
+        float w = shape[1];
+        for (int i = 0; i < box.Length; i += 2)
+        {
+            box[i] *= w;
+            if (i + 1 < box.Length)
+                box[i + 1] *= h;
+        }
+    }
+}

--- a/src/RapidTableNet/TableModel.cs
+++ b/src/RapidTableNet/TableModel.cs
@@ -1,0 +1,17 @@
+namespace RapidTableNet;
+
+public enum TableModel
+{
+    SlanetPlus,
+    PpStructureMobileV2
+}
+
+public static class TableModelExtensions
+{
+    public static string GetFileName(this TableModel model) => model switch
+    {
+        TableModel.SlanetPlus => "slanet-plus.onnx",
+        TableModel.PpStructureMobileV2 => "en_ppstructure_mobile_v2.0_SLANet_infer.onnx",
+        _ => throw new ArgumentOutOfRangeException(nameof(model), model, null)
+    };
+}

--- a/src/RapidTableNet/TablePreprocessor.cs
+++ b/src/RapidTableNet/TablePreprocessor.cs
@@ -1,0 +1,51 @@
+using Microsoft.ML.OnnxRuntime.Tensors;
+using SkiaSharp;
+
+namespace RapidTableNet;
+
+internal static class TablePreprocessor
+{
+    private const int MaxLen = 488;
+    private static readonly float[] Mean = [0.485f, 0.456f, 0.406f];
+    private static readonly float[] Std = [0.229f, 0.224f, 0.225f];
+    private const float Scale = 1f / 255f;
+
+    public static (DenseTensor<float> Tensor, float[] Shape) Process(SKBitmap src)
+    {
+        int h = src.Height;
+        int w = src.Width;
+        float ratio = MaxLen / (float)Math.Max(h, w);
+        int resizeH = (int)(h * ratio);
+        int resizeW = (int)(w * ratio);
+
+        var sampling = new SKSamplingOptions(SKFilterMode.Linear, SKMipmapMode.Linear);
+        using var resized = src.Resize(new SKSizeI(resizeW, resizeH), sampling);
+
+        using var padded = new SKBitmap(MaxLen, MaxLen);
+        padded.Erase(SKColors.Black);
+        using (var canvas = new SKCanvas(padded))
+        {
+            canvas.DrawBitmap(resized, 0, 0);
+        }
+
+        var tensor = new DenseTensor<float>(new[] { 1, 3, MaxLen, MaxLen });
+        ReadOnlySpan<byte> span = padded.GetPixelSpan();
+        int channels = padded.BytesPerPixel;
+
+        for (int r = 0; r < MaxLen; r++)
+        {
+            for (int c = 0; c < MaxLen; c++)
+            {
+                int idx = r * MaxLen + c;
+                for (int ch = 0; ch < 3; ch++)
+                {
+                    float val = span[idx * channels + ch];
+                    tensor[0, ch, r, c] = (val * Scale - Mean[ch]) / Std[ch];
+                }
+            }
+        }
+
+        float[] shape = [h, w, ratio, ratio, MaxLen, MaxLen];
+        return (tensor, shape);
+    }
+}

--- a/src/RapidTableNet/TableRecognizer.cs
+++ b/src/RapidTableNet/TableRecognizer.cs
@@ -1,0 +1,59 @@
+using Microsoft.ML.OnnxRuntime;
+using Microsoft.ML.OnnxRuntime.Tensors;
+using SkiaSharp;
+
+namespace RapidTableNet;
+
+public sealed class TableRecognizer : IDisposable
+{
+    private InferenceSession? _session;
+    private string _inputName = string.Empty;
+    private TableModel _model;
+    private TableLabelDecoder? _decoder;
+
+    public void InitModel(TableModel model, string? modelDir = null, int numThread = 1)
+    {
+        string fileName = model.GetFileName();
+        string path = modelDir == null ? fileName : Path.Combine(modelDir, fileName);
+        if (!File.Exists(path))
+        {
+            throw new FileNotFoundException($"Table model file does not exist: '{path}'.");
+        }
+
+        var options = new SessionOptions
+        {
+            GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_EXTENDED,
+            InterOpNumThreads = numThread,
+            IntraOpNumThreads = numThread
+        };
+
+        _session = new InferenceSession(path, options);
+        _inputName = _session.InputMetadata.Keys.First();
+        _model = model;
+        _decoder = new TableLabelDecoder(model);
+    }
+
+    public TableResult Detect(SKBitmap src)
+    {
+        if (_session == null || _decoder == null)
+        {
+            throw new InvalidOperationException("Model not initialised.");
+        }
+
+        var (tensor, shape) = TablePreprocessor.Process(src);
+        IReadOnlyCollection<NamedOnnxValue> inputs = new NamedOnnxValue[]
+        {
+            NamedOnnxValue.CreateFromTensor(_inputName, tensor)
+        };
+        using var results = _session.Run(inputs);
+        var bboxPreds = results[0].AsTensor<float>();
+        var structProbs = results[1].AsTensor<float>();
+        var (structure, boxes) = _decoder.Decode(bboxPreds, structProbs, shape);
+        return new TableResult(structure, boxes);
+    }
+
+    public void Dispose()
+    {
+        _session?.Dispose();
+    }
+}

--- a/src/RapidTableNet/TableResult.cs
+++ b/src/RapidTableNet/TableResult.cs
@@ -1,0 +1,3 @@
+namespace RapidTableNet;
+
+public sealed record TableResult(IReadOnlyList<string> Structure, IReadOnlyList<float[]> CellBoxes);

--- a/tests/MarkItDownNet.Tests/MarkItDownNet.Tests.csproj
+++ b/tests/MarkItDownNet.Tests/MarkItDownNet.Tests.csproj
@@ -26,6 +26,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\MarkItDownNet\MarkItDownNet.csproj" />
     <ProjectReference Include="..\..\src\RapidLayoutNet\RapidLayoutNet.csproj" />
+    <ProjectReference Include="..\..\src\RapidTableNet\RapidTableNet.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/MarkItDownNet.Tests/RapidTableTests.cs
+++ b/tests/MarkItDownNet.Tests/RapidTableTests.cs
@@ -1,0 +1,56 @@
+using RapidLayoutNet;
+using RapidTableNet;
+using SkiaSharp;
+
+namespace MarkItDownNet.Tests;
+
+public class RapidTableTests : IDisposable
+{
+    private readonly LayoutDetector _layout;
+    private readonly TableRecognizer _table;
+    private static readonly string TrainingDir = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "dataset", "training"));
+
+    public RapidTableTests()
+    {
+        string layoutModel = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "src", "RapidLayoutNet", "models", "PP-DocLayout-S_infer.onnx"));
+        _layout = new LayoutDetector();
+        _layout.InitModel(layoutModel);
+
+        string tableModelDir = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "src", "RapidTableNet", "models"));
+        _table = new TableRecognizer();
+        _table.InitModel(TableModel.SlanetPlus, tableModelDir);
+    }
+
+    public void Dispose()
+    {
+        _layout.Dispose();
+        _table.Dispose();
+    }
+
+    [Fact]
+    public void Detects_structure_on_training_image()
+    {
+        string path = Path.Combine(TrainingDir, "busta_paga_internet.jpeg");
+        using var bmp = SKBitmap.Decode(path);
+        var boxes = _layout.Detect(bmp, 0.3f);
+        var tableBox = boxes.First(b => b.Label == LayoutLabel.Table);
+        var rect = new SKRectI((int)tableBox.X1, (int)tableBox.Y1, (int)tableBox.X2, (int)tableBox.Y2);
+        using var img = SKImage.FromBitmap(bmp);
+        using var subset = img.Subset(rect);
+        using var tableBmp = SKBitmap.FromImage(subset);
+        var result = _table.Detect(tableBmp);
+        Assert.NotEmpty(result.Structure);
+        Assert.NotEmpty(result.CellBoxes);
+    }
+
+    [Fact]
+    public void Initialises_all_models()
+    {
+        string modelDir = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "src", "RapidTableNet", "models"));
+        foreach (TableModel m in Enum.GetValues<TableModel>())
+        {
+            using var rec = new TableRecognizer();
+            rec.InitModel(m, modelDir);
+        }
+    }
+}

--- a/tools/RapidTableDataset/Program.cs
+++ b/tools/RapidTableDataset/Program.cs
@@ -1,0 +1,119 @@
+using RapidLayoutNet;
+using RapidTableNet;
+using SkiaSharp;
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+
+record TableInfo(float[] Box, double RecognitionTimeMs, int CellCount, int TokenCount);
+record ImageInfo(string FileName, double LayoutTimeMs, List<TableInfo> Tables);
+
+class Program
+{
+    static void Main()
+    {
+        var baseDir = AppContext.BaseDirectory;
+        var repoRoot = Path.GetFullPath(Path.Combine(baseDir, "..", "..", "..", "..", ".."));
+        var dataDir = Path.Combine(repoRoot, "dataset", "training");
+        var layoutModel = Path.Combine(repoRoot, "src", "RapidLayoutNet", "models", "PP-DocLayout-S_infer.onnx");
+        var tableModelDir = Path.Combine(repoRoot, "src", "RapidTableNet", "models");
+        var reportPath = Path.Combine(repoRoot, "docs", "rapidtable_training_report.md");
+
+        using var layout = new LayoutDetector();
+        layout.InitModel(layoutModel);
+        using var tableRec = new TableRecognizer();
+        tableRec.InitModel(TableModel.SlanetPlus, tableModelDir);
+
+        var imageFiles = Directory.EnumerateFiles(dataDir)
+            .Where(f => {
+                var ext = Path.GetExtension(f).ToLowerInvariant();
+                return ext == ".png" || ext == ".jpg" || ext == ".jpeg";
+            })
+            .OrderBy(f => f)
+            .ToList();
+
+        var images = new List<ImageInfo>();
+
+        foreach (var path in imageFiles)
+        {
+            var fileName = Path.GetFileName(path);
+            using var src = SKBitmap.Decode(path);
+            var layoutSw = Stopwatch.StartNew();
+            var boxes = layout.Detect(src);
+            layoutSw.Stop();
+            var tableBoxes = boxes.Where(b => b.Label == LayoutLabel.Table).ToArray();
+            var tables = new List<TableInfo>();
+            foreach (var box in tableBoxes)
+            {
+                var rect = new SKRectI((int)box.X1, (int)box.Y1, (int)box.X2, (int)box.Y2);
+                using var tableBmp = new SKBitmap(rect.Width, rect.Height);
+                using (var canvas = new SKCanvas(tableBmp))
+                {
+                    canvas.DrawBitmap(src, rect, new SKRectI(0, 0, rect.Width, rect.Height));
+                }
+                var recogSw = Stopwatch.StartNew();
+                var result = tableRec.Detect(tableBmp);
+                recogSw.Stop();
+                tables.Add(new TableInfo(
+                    Box: [box.X1, box.Y1, box.X2, box.Y2],
+                    RecognitionTimeMs: recogSw.Elapsed.TotalMilliseconds,
+                    CellCount: result.CellBoxes.Count,
+                    TokenCount: result.Structure.Count));
+            }
+            images.Add(new ImageInfo(fileName, layoutSw.Elapsed.TotalMilliseconds, tables));
+
+            var json = new
+            {
+                layout_time_ms = layoutSw.Elapsed.TotalMilliseconds,
+                tables = tables.Select(t => new
+                {
+                    box = t.Box,
+                    recognition_time_ms = t.RecognitionTimeMs,
+                    cell_count = t.CellCount,
+                    token_count = t.TokenCount
+                })
+            };
+            var jsonPath = Path.Combine(dataDir, fileName + ".rapidtable.json");
+            File.WriteAllText(jsonPath, JsonSerializer.Serialize(json, new JsonSerializerOptions { WriteIndented = true }));
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine("# RapidTableNet training dataset analysis");
+        sb.AppendLine();
+        sb.AppendLine("Model: SlanetPlus");
+        sb.AppendLine();
+        sb.AppendLine("## Summary");
+        sb.AppendLine();
+        sb.AppendLine("| Image | Tables | Layout ms |");
+        sb.AppendLine("| --- | --- | --- |");
+        foreach (var img in images)
+        {
+            sb.AppendLine($"| {img.FileName} | {img.Tables.Count} | {img.LayoutTimeMs:F1} |");
+        }
+        sb.AppendLine();
+        sb.AppendLine("## Detailed results");
+        sb.AppendLine();
+        foreach (var img in images)
+        {
+            sb.AppendLine($"### {img.FileName}");
+            sb.AppendLine($"Layout time: {img.LayoutTimeMs:F1} ms");
+            sb.AppendLine($"Detected tables: {img.Tables.Count}");
+            sb.AppendLine();
+            if (img.Tables.Count > 0)
+            {
+                sb.AppendLine("| Table | Bounding Box [x1,y1,x2,y2] | Recognition ms | Cells | Tokens |");
+                sb.AppendLine("| --- | --- | --- | --- | --- |");
+                for (int i = 0; i < img.Tables.Count; i++)
+                {
+                    var t = img.Tables[i];
+                    sb.AppendLine($"| {i + 1} | [{t.Box[0]:F0},{t.Box[1]:F0},{t.Box[2]:F0},{t.Box[3]:F0}] | {t.RecognitionTimeMs:F1} | {t.CellCount} | {t.TokenCount} |");
+                }
+                sb.AppendLine();
+                sb.AppendLine($"Output file: `dataset/training/{img.FileName}.rapidtable.json`");
+            }
+            sb.AppendLine();
+        }
+
+        File.WriteAllText(reportPath, sb.ToString());
+    }
+}

--- a/tools/RapidTableDataset/RapidTableDataset.csproj
+++ b/tools/RapidTableDataset/RapidTableDataset.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/RapidLayoutNet/RapidLayoutNet.csproj" />
+    <ProjectReference Include="../../src/RapidTableNet/RapidTableNet.csproj" />
+    <PackageReference Include="SkiaSharp" Version="3.119.0" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.0" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add RapidTableNet library with SLANet-based ONNX table models
- expose TableModel enum and TableRecognizer for structure decoding
- add unit tests cropping table region via RapidLayout and feeding to RapidTable
- add RapidTableDataset tool generating per-image JSON outputs and a detailed Markdown timing report for training images

## Testing
- `dotnet run --project tools/RapidTableDataset`
- `dotnet test tests/MarkItDownNet.Tests/MarkItDownNet.Tests.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68ad4436f6a48325bf4e7f9bb04f49c7