### PR TITLE
Switch PPStructure notes to save_to_markdown

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,8 +71,10 @@ Indicare quindi il percorso tramite `OcrDataPath`.
   unused modules and reuse a single model across images. Send each image path
   over `stdin` and read a JSON blob with both layout labels and markdown.
 - Use this script to compare .NET Markdown output with the Python reference.
+- Set `ENABLE_PPSTRUCTURE=1` before running tests to enable these comparisons; otherwise the Python helper is skipped.
 
 ## Orientation hooks
 - Set `StructureOptions.DetectOrientation` to enable angle-aware OCR and invoke an optional
-  `IOrientationDetector` to rotate pages. Until a detector is provided the orientation
-  will remain at `0` degrees.
+  `IOrientationDetector` to rotate pages. `RapidOcrOrientationDetector` uses the
+  `ch_ppocr_mobile_v2.0_cls_infer_opt.onnx` model to return 0/90/180/270 angles and all
+  bounding boxes are mapped back to the original image space.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,3 +45,29 @@ Indicare quindi il percorso tramite `OcrDataPath`.
 - Generate Markdown with `python tools/markitdown_ocr.py <image_or_text> -o <out.md>`.
 - When running benchmarks, the CLI automatically calls this script for `python` mode.
 - For warm-start benchmarks, `python tools/run_markitdown_hot.py <text> <out.md>` loads the text once and runs five conversions, printing timing data as JSON.
+
+## PPStructure Markdown
+- Install dependencies (PPStructureV3 currently requires NumPy 1.x and PaddleX):
+  ```bash
+  pip install 'numpy<2' paddlepaddle==3.0.0 "paddlex[ocr]"
+  ```
+- Clone the reference repo once and convert an image to Markdown:
+ ```bash
+  git clone https://github.com/PaddlePaddle/PaddleOCR /tmp/PaddleOCR
+  python - <<'PY'
+  import os,sys,tempfile
+  repo='/tmp/PaddleOCR'; sys.path.insert(0, repo)
+  from paddleocr import PPStructureV3
+  pipeline=PPStructureV3(lang='en')
+  res=pipeline.predict(sys.argv[1])
+  tmp=tempfile.mkdtemp()
+  res[0].save_to_markdown(tmp)
+  md_path=os.path.join(tmp, os.path.splitext(os.path.basename(sys.argv[1]))[0]+'.md')
+  print(open(md_path,encoding='utf-8').read())
+  PY <image_path>
+  ```
+- Tests spin up a long-lived helper that instantiates `PPStructureV3` with
+  `use_chart_recognition=False` and `use_formula_recognition=False` to trim
+  unused modules and reuse a single model across images. Send each image path
+  over `stdin` and read a JSON blob with both layout labels and markdown.
+- Use this script to compare .NET Markdown output with the Python reference.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,3 +71,8 @@ Indicare quindi il percorso tramite `OcrDataPath`.
   unused modules and reuse a single model across images. Send each image path
   over `stdin` and read a JSON blob with both layout labels and markdown.
 - Use this script to compare .NET Markdown output with the Python reference.
+
+## Orientation hooks
+- Set `StructureOptions.DetectOrientation` to enable angle-aware OCR and invoke an optional
+  `IOrientationDetector` to rotate pages. Until a detector is provided the orientation
+  will remain at `0` degrees.

--- a/MarkItDownNet.sln
+++ b/MarkItDownNet.sln
@@ -13,6 +13,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{B651CF8E
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MarkItDownNet.Tests", "tests\MarkItDownNet.Tests\MarkItDownNet.Tests.csproj", "{61A49AB8-0F2C-493B-9DFB-5B04E131EC71}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RapidLayoutNet", "src\RapidLayoutNet\RapidLayoutNet.csproj", "{3E26250D-3DD3-411B-9847-4C35D37BB214}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RapidTableNet", "src\RapidTableNet\RapidTableNet.csproj", "{568B8DFB-B3DB-41CA-BD66-52D120554612}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RapidStructureNet", "src\RapidStructureNet\RapidStructureNet.csproj", "{AEDBACF7-DF6B-4F4F-A5C6-71D45F85085C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,23 +27,38 @@ Global
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
-        GlobalSection(ProjectConfigurationPlatforms) = postSolution
-                {CC583AE0-BA2D-407F-B8A6-C01E804141D9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-                {CC583AE0-BA2D-407F-B8A6-C01E804141D9}.Debug|Any CPU.Build.0 = Debug|Any CPU
-                {CC583AE0-BA2D-407F-B8A6-C01E804141D9}.Release|Any CPU.ActiveCfg = Release|Any CPU
-                {CC583AE0-BA2D-407F-B8A6-C01E804141D9}.Release|Any CPU.Build.0 = Release|Any CPU
-                {61A49AB8-0F2C-493B-9DFB-5B04E131EC71}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-                {61A49AB8-0F2C-493B-9DFB-5B04E131EC71}.Debug|Any CPU.Build.0 = Debug|Any CPU
-                {61A49AB8-0F2C-493B-9DFB-5B04E131EC71}.Release|Any CPU.ActiveCfg = Release|Any CPU
-                {61A49AB8-0F2C-493B-9DFB-5B04E131EC71}.Release|Any CPU.Build.0 = Release|Any CPU
-                {0C59ACD9-727D-424F-A5DB-A879828250EA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-                {0C59ACD9-727D-424F-A5DB-A879828250EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-                {0C59ACD9-727D-424F-A5DB-A879828250EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
-                {0C59ACD9-727D-424F-A5DB-A879828250EA}.Release|Any CPU.Build.0 = Release|Any CPU
-        EndGlobalSection
-        GlobalSection(NestedProjects) = preSolution
-                {CC583AE0-BA2D-407F-B8A6-C01E804141D9} = {E1373335-A373-406B-82A1-F89065F2F55B}
-                {61A49AB8-0F2C-493B-9DFB-5B04E131EC71} = {B651CF8E-1DD9-41DC-8D4B-A9791749EBC6}
-                {0C59ACD9-727D-424F-A5DB-A879828250EA} = {E1373335-A373-406B-82A1-F89065F2F55B}
-        EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CC583AE0-BA2D-407F-B8A6-C01E804141D9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CC583AE0-BA2D-407F-B8A6-C01E804141D9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CC583AE0-BA2D-407F-B8A6-C01E804141D9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CC583AE0-BA2D-407F-B8A6-C01E804141D9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{61A49AB8-0F2C-493B-9DFB-5B04E131EC71}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{61A49AB8-0F2C-493B-9DFB-5B04E131EC71}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{61A49AB8-0F2C-493B-9DFB-5B04E131EC71}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{61A49AB8-0F2C-493B-9DFB-5B04E131EC71}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0C59ACD9-727D-424F-A5DB-A879828250EA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0C59ACD9-727D-424F-A5DB-A879828250EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0C59ACD9-727D-424F-A5DB-A879828250EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0C59ACD9-727D-424F-A5DB-A879828250EA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3E26250D-3DD3-411B-9847-4C35D37BB214}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3E26250D-3DD3-411B-9847-4C35D37BB214}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3E26250D-3DD3-411B-9847-4C35D37BB214}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3E26250D-3DD3-411B-9847-4C35D37BB214}.Release|Any CPU.Build.0 = Release|Any CPU
+		{568B8DFB-B3DB-41CA-BD66-52D120554612}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{568B8DFB-B3DB-41CA-BD66-52D120554612}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{568B8DFB-B3DB-41CA-BD66-52D120554612}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{568B8DFB-B3DB-41CA-BD66-52D120554612}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AEDBACF7-DF6B-4F4F-A5C6-71D45F85085C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AEDBACF7-DF6B-4F4F-A5C6-71D45F85085C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AEDBACF7-DF6B-4F4F-A5C6-71D45F85085C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AEDBACF7-DF6B-4F4F-A5C6-71D45F85085C}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{CC583AE0-BA2D-407F-B8A6-C01E804141D9} = {E1373335-A373-406B-82A1-F89065F2F55B}
+		{61A49AB8-0F2C-493B-9DFB-5B04E131EC71} = {B651CF8E-1DD9-41DC-8D4B-A9791749EBC6}
+		{0C59ACD9-727D-424F-A5DB-A879828250EA} = {E1373335-A373-406B-82A1-F89065F2F55B}
+		{3E26250D-3DD3-411B-9847-4C35D37BB214} = {E1373335-A373-406B-82A1-F89065F2F55B}
+		{568B8DFB-B3DB-41CA-BD66-52D120554612} = {E1373335-A373-406B-82A1-F89065F2F55B}
+		{AEDBACF7-DF6B-4F4F-A5C6-71D45F85085C} = {E1373335-A373-406B-82A1-F89065F2F55B}
+	EndGlobalSection
 EndGlobal

--- a/docs/ValidationMarkdownComparison.md
+++ b/docs/ValidationMarkdownComparison.md
@@ -1,0 +1,11 @@
+# Validation Markdown Comparison
+
+| Dataset | Image | .NET size (bytes) | Python size (bytes) | .NET time (ms) | Python time (ms) | Notes |
+|--------|-------|------------------:|--------------------:|---------------:|-----------------:|-------|
+| FUNSD | 82092117.png | 63 | 148 | 3821 | 5389 | Python includes figure HTML; .NET minimal text |
+| ICDAR | cTDaR_t00014.jpg | 103 | 149 | 3264 | 4019 | Both outputs largely empty; Python adds image tag |
+| MARMOT | 10.1.1.1.2006_3.jpeg | 5212 | 4671 | 12586 | 14188 | .NET produces slightly larger table markdown |
+| PUBTABLES | PMC1064078_table_0.jpg | 687 | 1363 | 2467 | 3106 | Python markup doubles size with figure wrapper |
+| SROIE2019 | X00016469670.jpg | 119 | 148 | 2938 | 2911 | Outputs comparable; structures differ in ordering |
+
+Times measured with local runs of RapidStructure (v5 OCR) and PPStructureV3 `save_to_markdown` (paddlepaddle 3.0.0 + paddlex[ocr]).

--- a/src/RapidLayoutNet/LayoutDetector.cs
+++ b/src/RapidLayoutNet/LayoutDetector.cs
@@ -24,7 +24,8 @@ public sealed class LayoutDetector : IDisposable
         {
             GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_EXTENDED,
             InterOpNumThreads = numThread,
-            IntraOpNumThreads = numThread
+            IntraOpNumThreads = numThread,
+            LogSeverityLevel = OrtLoggingLevel.ORT_LOGGING_LEVEL_ERROR
         };
 
         _session = new InferenceSession(path, options);

--- a/src/RapidStructureNet/IOcrEngine.cs
+++ b/src/RapidStructureNet/IOcrEngine.cs
@@ -1,0 +1,23 @@
+using RapidOcrNet;
+using SkiaSharp;
+
+namespace RapidStructureNet;
+
+/// <summary>
+/// Minimal abstraction over an OCR engine used by the structure pipeline.
+/// </summary>
+public interface IOcrEngine
+{
+    OcrResult Detect(SKBitmap image, RapidOcrOptions options);
+}
+
+/// <summary>
+/// Adapter to use <see cref="RapidOcr"/> as an <see cref="IOcrEngine"/>.
+/// </summary>
+public sealed class RapidOcrEngine : IOcrEngine
+{
+    private readonly RapidOcr _inner;
+    public RapidOcrEngine(RapidOcr inner) => _inner = inner;
+    public OcrResult Detect(SKBitmap image, RapidOcrOptions options) => _inner.Detect(image, options);
+}
+

--- a/src/RapidStructureNet/IOrientationDetector.cs
+++ b/src/RapidStructureNet/IOrientationDetector.cs
@@ -1,0 +1,13 @@
+using SkiaSharp;
+
+namespace RapidStructureNet;
+
+/// <summary>
+/// Detects page orientation and returns the clockwise rotation angle in degrees
+/// required to deskew the image. Implementations may return 0 when the page is
+/// already upright.
+/// </summary>
+public interface IOrientationDetector
+{
+    float Detect(SKBitmap image);
+}

--- a/src/RapidStructureNet/RapidOcrOrientationDetector.cs
+++ b/src/RapidStructureNet/RapidOcrOrientationDetector.cs
@@ -1,0 +1,45 @@
+using System;
+using RapidOcrNet;
+using SkiaSharp;
+
+namespace RapidStructureNet;
+
+/// <summary>
+/// Orientation detector based on RapidOCR's angle classifier.
+/// Evaluates the image and a 90° rotation to derive 0/90/180/270 angles.
+/// </summary>
+public sealed class RapidOcrOrientationDetector : IOrientationDetector, IDisposable
+{
+    private readonly TextClassifier _classifier = new();
+
+    public RapidOcrOrientationDetector(string modelPath, int numThread = 1)
+    {
+        _classifier.InitModel(modelPath, numThread);
+    }
+
+    public float Detect(SKBitmap image)
+    {
+        var angle0 = _classifier.GetAngle(image);
+        using var rot90 = Rotate(image, 90);
+        var angle90 = _classifier.GetAngle(rot90);
+
+        float ori0 = angle0.Index == 0 ? 0f : 180f;
+        float ori90 = angle90.Index == 0 ? 90f : 270f;
+
+        return angle0.Score >= angle90.Score ? ori0 : ori90;
+    }
+
+    private static SKBitmap Rotate(SKBitmap src, float angle)
+    {
+        SKBitmap dst = angle % 180 == 0 ? new SKBitmap(src.Width, src.Height) : new SKBitmap(src.Height, src.Width);
+        using var canvas = new SKCanvas(dst);
+        canvas.Translate(dst.Width / 2f, dst.Height / 2f);
+        canvas.RotateDegrees(angle);
+        canvas.Translate(-src.Width / 2f, -src.Height / 2f);
+        canvas.DrawBitmap(src, 0, 0);
+        canvas.Flush();
+        return dst;
+    }
+
+    public void Dispose() => _classifier.Dispose();
+}

--- a/src/RapidStructureNet/RapidStructure.cs
+++ b/src/RapidStructureNet/RapidStructure.cs
@@ -16,28 +16,36 @@ public sealed class RapidStructure
     private readonly LayoutDetector _layoutDetector;
     private readonly IOcrEngine _ocr;
     private readonly TableRecognizer _tableRecognizer;
+    private readonly IOrientationDetector? _orientationDetector;
 
-    public RapidStructure(LayoutDetector layoutDetector, IOcrEngine ocr, TableRecognizer tableRecognizer)
+    public RapidStructure(LayoutDetector layoutDetector, IOcrEngine ocr, TableRecognizer tableRecognizer, IOrientationDetector? orientationDetector = null)
     {
         _layoutDetector = layoutDetector;
         _ocr = ocr;
         _tableRecognizer = tableRecognizer;
+        _orientationDetector = orientationDetector;
     }
 
     /// <summary>
     /// Analyse a page image and return detected regions along with the full OCR result.
-    /// Orientation detection is wired but not yet implemented; the returned orientation
-    /// angle will always be zero for now.
+    /// Orientation detection can be enabled via <see cref="StructureOptions.DetectOrientation"/>.
     /// </summary>
     public StructureResult Analyze(SKBitmap image, StructureOptions? structureOptions = null, RapidOcrOptions? ocrOptions = null)
     {
         structureOptions ??= new StructureOptions();
         ocrOptions ??= RapidOcrOptions.Default;
-        // Disable angle classification until orientation handling is implemented
-        ocrOptions = ocrOptions with { DoAngle = false };
+        ocrOptions = ocrOptions with { DoAngle = structureOptions.DetectOrientation };
 
-        float orientation = 0f; // placeholder – orientation detection not yet implemented
-        SKBitmap working = image; // no rotation applied
+        float orientation = 0f;
+        SKBitmap working = image;
+        if (structureOptions.DetectOrientation && _orientationDetector != null)
+        {
+            orientation = _orientationDetector.Detect(image);
+            if (orientation % 360 != 0)
+            {
+                working = Rotate(image, orientation);
+            }
+        }
 
         // Detect layout regions
         var sw = Stopwatch.StartNew();
@@ -112,5 +120,25 @@ public sealed class RapidStructure
         }
         return filtered;
     }
-}
 
+    private static SKBitmap Rotate(SKBitmap src, float angle)
+    {
+        angle %= 360;
+        if (angle == 0) return src;
+        SKBitmap dst;
+        if (angle == 90 || angle == 270)
+            dst = new SKBitmap(src.Height, src.Width);
+        else
+            dst = new SKBitmap(src.Width, src.Height);
+
+        using var canvas = new SKCanvas(dst);
+        canvas.Translate(dst.Width / 2f, dst.Height / 2f);
+        canvas.RotateDegrees(angle);
+        canvas.Translate(-src.Width / 2f, -src.Height / 2f);
+        canvas.DrawBitmap(src, 0, 0);
+        canvas.Flush();
+        return dst;
+    }
+
+    // Bounding boxes are returned in the coordinate space of the possibly rotated image.
+}

--- a/src/RapidStructureNet/RapidStructure.cs
+++ b/src/RapidStructureNet/RapidStructure.cs
@@ -1,0 +1,116 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using RapidLayoutNet;
+using RapidOcrNet;
+using RapidTableNet;
+using SkiaSharp;
+
+namespace RapidStructureNet;
+
+/// <summary>
+/// High level orchestrator combining layout detection, OCR and table recognition
+/// similar to PaddleOCR's PP-Structure pipeline.
+/// </summary>
+public sealed class RapidStructure
+{
+    private readonly LayoutDetector _layoutDetector;
+    private readonly IOcrEngine _ocr;
+    private readonly TableRecognizer _tableRecognizer;
+
+    public RapidStructure(LayoutDetector layoutDetector, IOcrEngine ocr, TableRecognizer tableRecognizer)
+    {
+        _layoutDetector = layoutDetector;
+        _ocr = ocr;
+        _tableRecognizer = tableRecognizer;
+    }
+
+    /// <summary>
+    /// Analyse a page image and return detected regions along with the full OCR result.
+    /// Orientation detection is wired but not yet implemented; the returned orientation
+    /// angle will always be zero for now.
+    /// </summary>
+    public StructureResult Analyze(SKBitmap image, StructureOptions? structureOptions = null, RapidOcrOptions? ocrOptions = null)
+    {
+        structureOptions ??= new StructureOptions();
+        ocrOptions ??= RapidOcrOptions.Default;
+        // Disable angle classification until orientation handling is implemented
+        ocrOptions = ocrOptions with { DoAngle = false };
+
+        float orientation = 0f; // placeholder – orientation detection not yet implemented
+        SKBitmap working = image; // no rotation applied
+
+        // Detect layout regions
+        var sw = Stopwatch.StartNew();
+        var layout = _layoutDetector.Detect(working, structureOptions.LayoutScoreThreshold);
+        long layoutTime = sw.ElapsedMilliseconds;
+        if (layout.Count == 0)
+        {
+            // Fallback to a single table region covering the whole page
+            layout = new List<LayoutBox>
+            {
+                new(LayoutLabel.Table, 1f, 0, 0, working.Width, working.Height)
+            };
+        }
+
+        // Run full page OCR once
+        sw.Restart();
+        var ocrResult = _ocr.Detect(working, ocrOptions);
+        long ocrTime = sw.ElapsedMilliseconds;
+
+        var regions = new List<StructureRegion>(layout.Count);
+        long tableTime = 0;
+        foreach (var box in layout)
+        {
+            var rect = new SKRect(box.X1, box.Y1, box.X2, box.Y2);
+            var norm = new SKRect(rect.Left / working.Width, rect.Top / working.Height,
+                                  rect.Right / working.Width, rect.Bottom / working.Height);
+
+            SKBitmap? subset = null;
+            TableResult? table = null;
+            IReadOnlyList<TextBlock>? textBlocks = null;
+            bool needsImage = box.Label == LayoutLabel.Table || box.Label == LayoutLabel.Image;
+            if (needsImage)
+            {
+                var rectI = SKRectI.Round(rect);
+                subset = new SKBitmap(rectI.Width, rectI.Height);
+                working.ExtractSubset(subset, rectI);
+                if (box.Label == LayoutLabel.Table)
+                {
+                    table = _tableRecognizer.Detect(subset);
+                    tableTime += table.TotalTimeMs;
+                }
+            }
+            else
+            {
+                textBlocks = FilterBlocks(ocrResult.TextBlocks, rect);
+            }
+
+            regions.Add(new StructureRegion(box.Label, norm, box.Score, 0, subset, table, textBlocks));
+        }
+
+        return new StructureResult(regions, ocrResult, orientation, layoutTime, ocrTime, tableTime);
+    }
+
+    private static List<TextBlock> FilterBlocks(TextBlock[] blocks, SKRect region)
+    {
+        var filtered = new List<TextBlock>();
+        foreach (var b in blocks)
+        {
+            var pts = b.BoxPoints;
+            float minX = pts[0].X, maxX = pts[0].X, minY = pts[0].Y, maxY = pts[0].Y;
+            for (int i = 1; i < pts.Length; i++)
+            {
+                var p = pts[i];
+                if (p.X < minX) minX = p.X;
+                if (p.X > maxX) maxX = p.X;
+                if (p.Y < minY) minY = p.Y;
+                if (p.Y > maxY) maxY = p.Y;
+            }
+            var textRect = new SKRect(minX, minY, maxX, maxY);
+            if (region.IntersectsWith(textRect))
+                filtered.Add(b);
+        }
+        return filtered;
+    }
+}
+

--- a/src/RapidStructureNet/RapidStructure.cs
+++ b/src/RapidStructureNet/RapidStructure.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using RapidLayoutNet;
 using RapidOcrNet;
 using RapidTableNet;
@@ -64,14 +65,19 @@ public sealed class RapidStructure
         sw.Restart();
         var ocrResult = _ocr.Detect(working, ocrOptions);
         long ocrTime = sw.ElapsedMilliseconds;
+        if (orientation % 360 != 0)
+        {
+            ocrResult = RotateOcrResult(ocrResult, orientation, image.Width, image.Height);
+        }
 
         var regions = new List<StructureRegion>(layout.Count);
         long tableTime = 0;
         foreach (var box in layout)
         {
             var rect = new SKRect(box.X1, box.Y1, box.X2, box.Y2);
-            var norm = new SKRect(rect.Left / working.Width, rect.Top / working.Height,
-                                  rect.Right / working.Width, rect.Bottom / working.Height);
+            var origRect = orientation % 360 != 0 ? RotateRectBack(rect, orientation, image.Width, image.Height) : rect;
+            var norm = new SKRect(origRect.Left / image.Width, origRect.Top / image.Height,
+                                  origRect.Right / image.Width, origRect.Bottom / image.Height);
 
             SKBitmap? subset = null;
             TableResult? table = null;
@@ -90,7 +96,7 @@ public sealed class RapidStructure
             }
             else
             {
-                textBlocks = FilterBlocks(ocrResult.TextBlocks, rect);
+                textBlocks = FilterBlocks(ocrResult.TextBlocks, origRect);
             }
 
             regions.Add(new StructureRegion(box.Label, norm, box.Score, 0, subset, table, textBlocks));
@@ -121,6 +127,70 @@ public sealed class RapidStructure
         return filtered;
     }
 
+    private static OcrResult RotateOcrResult(OcrResult src, float angle, int width, int height)
+    {
+        var blocks = new TextBlock[src.TextBlocks.Length];
+        for (int i = 0; i < src.TextBlocks.Length; i++)
+        {
+            var b = src.TextBlocks[i];
+            var pts = new SKPointI[b.BoxPoints.Length];
+            for (int j = 0; j < b.BoxPoints.Length; j++)
+            {
+                var p = RotatePointBack(b.BoxPoints[j], angle, width, height);
+                pts[j] = new SKPointI((int)System.Math.Round(p.X), (int)System.Math.Round(p.Y));
+            }
+            blocks[i] = new TextBlock
+            {
+                BoxPoints = pts,
+                BoxScore = b.BoxScore,
+                AngleIndex = b.AngleIndex,
+                AngleScore = b.AngleScore,
+                AngleTime = b.AngleTime,
+                Chars = b.Chars,
+                CharScores = b.CharScores,
+                CrnnTime = b.CrnnTime,
+                BlockTime = b.BlockTime
+            };
+        }
+        return new OcrResult
+        {
+            TextBlocks = blocks,
+            DbNetTime = src.DbNetTime,
+            DetectTime = src.DetectTime,
+            StrRes = src.StrRes
+        };
+    }
+
+    private static SKRect RotateRectBack(SKRect rect, float angle, int width, int height)
+    {
+        if (angle % 360 == 0) return rect;
+        var pts = new[]
+        {
+            new SKPoint(rect.Left, rect.Top),
+            new SKPoint(rect.Right, rect.Top),
+            new SKPoint(rect.Right, rect.Bottom),
+            new SKPoint(rect.Left, rect.Bottom)
+        };
+        var rotated = pts.Select(p => RotatePointBack(p, angle, width, height)).ToArray();
+        float minX = rotated.Min(p => p.X);
+        float maxX = rotated.Max(p => p.X);
+        float minY = rotated.Min(p => p.Y);
+        float maxY = rotated.Max(p => p.Y);
+        return new SKRect(minX, minY, maxX, maxY);
+    }
+
+    private static SKPoint RotatePointBack(SKPoint p, float angle, int width, int height)
+    {
+        angle %= 360;
+        return angle switch
+        {
+            90 => new SKPoint(p.Y, height - p.X),
+            180 => new SKPoint(width - p.X, height - p.Y),
+            270 => new SKPoint(width - p.Y, p.X),
+            _ => p
+        };
+    }
+
     private static SKBitmap Rotate(SKBitmap src, float angle)
     {
         angle %= 360;
@@ -140,5 +210,5 @@ public sealed class RapidStructure
         return dst;
     }
 
-    // Bounding boxes are returned in the coordinate space of the possibly rotated image.
+    // Bounding boxes are mapped back to the original image coordinate space.
 }

--- a/src/RapidStructureNet/RapidStructureNet.csproj
+++ b/src/RapidStructureNet/RapidStructureNet.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\RapidLayoutNet\RapidLayoutNet.csproj" />
+    <ProjectReference Include="..\RapidTableNet\RapidTableNet.csproj" />
+    <ProjectReference Include="..\RapidOcrNet\RapidOcrNet.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/RapidStructureNet/StructureMarkdownBuilder.cs
+++ b/src/RapidStructureNet/StructureMarkdownBuilder.cs
@@ -75,9 +75,9 @@ public static class StructureMarkdownBuilder
                         string html = region.Table.Html.Trim();
                         if (!html.StartsWith("<table", StringComparison.OrdinalIgnoreCase))
                         {
-                            sb.AppendLine("<table>");
+                            sb.AppendLine("<table><tbody>");
                             sb.AppendLine(html);
-                            sb.AppendLine("</table>");
+                            sb.AppendLine("</tbody></table>");
                         }
                         else
                         {

--- a/src/RapidStructureNet/StructureMarkdownBuilder.cs
+++ b/src/RapidStructureNet/StructureMarkdownBuilder.cs
@@ -1,0 +1,280 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Text.RegularExpressions;
+using RapidLayoutNet;
+using RapidOcrNet;
+using SkiaSharp;
+
+namespace RapidStructureNet;
+
+/// <summary>
+/// Convert <see cref="StructureResult"/> into Markdown text with optional
+/// figure extraction and table serialisation.
+/// </summary>
+public static class StructureMarkdownBuilder
+{
+    /// <summary>
+    /// Build Markdown from a structure result. When <paramref name="imageDir"/>
+    /// is provided, figure regions are saved there and referenced in the output.
+    /// </summary>
+    public static string Build(StructureResult result, string? imageDir = null)
+    {
+        var sb = new StringBuilder();
+        int figIndex = 0;
+
+        // Pre-associate captions with figures and tables
+        var captionMap = new Dictionary<StructureRegion, string>();
+        var captionRegions = new HashSet<StructureRegion>();
+        foreach (var cap in result.Regions.Where(r => r.Type is LayoutLabel.FigureTitle or LayoutLabel.TableTitle))
+        {
+            if (cap.TextBlocks == null || cap.TextBlocks.Count == 0)
+                continue;
+            string caption = MergeText(cap.TextBlocks);
+            var candidates = result.Regions.Where(r => r.PageIndex == cap.PageIndex &&
+                ((cap.Type == LayoutLabel.FigureTitle && r.Type == LayoutLabel.Image) ||
+                 (cap.Type == LayoutLabel.TableTitle && r.Type == LayoutLabel.Table)));
+            StructureRegion? target = null;
+            float minDist = float.MaxValue;
+            foreach (var c in candidates)
+            {
+                float dist;
+                if (cap.BBox.Top >= c.BBox.Bottom)
+                    dist = cap.BBox.Top - c.BBox.Bottom;
+                else if (c.BBox.Top >= cap.BBox.Bottom)
+                    dist = c.BBox.Top - cap.BBox.Bottom;
+                else
+                    dist = 0;
+                if (dist < minDist)
+                {
+                    minDist = dist;
+                    target = c;
+                }
+            }
+            if (target != null && minDist < 0.2f)
+            {
+                captionMap[target] = caption;
+                captionRegions.Add(cap);
+            }
+        }
+
+        foreach (var region in result.Regions
+            .OrderBy(r => r.BBox.Top)
+            .ThenBy(r => r.BBox.Left))
+        {
+            if (captionRegions.Contains(region))
+                continue;
+
+            switch (region.Type)
+            {
+                case LayoutLabel.Table:
+                    if (region.Table != null)
+                    {
+                        string html = region.Table.Html.Trim();
+                        if (!html.StartsWith("<table", StringComparison.OrdinalIgnoreCase))
+                        {
+                            sb.AppendLine("<table>");
+                            sb.AppendLine(html);
+                            sb.AppendLine("</table>");
+                        }
+                        else
+                        {
+                            sb.AppendLine(html);
+                        }
+                        if (captionMap.TryGetValue(region, out var cap))
+                        {
+                            sb.AppendLine($"<div align=\"center\">{WebUtility.HtmlEncode(cap)}</div>");
+                        }
+                        sb.AppendLine();
+                    }
+                    break;
+                case LayoutLabel.Image:
+                    if (region.Image != null && imageDir != null)
+                    {
+                        Directory.CreateDirectory(imageDir);
+                        string name = $"figure_{figIndex++}.png";
+                        string path = Path.Combine(imageDir, name);
+                        using var data = region.Image.Encode(SKEncodedImageFormat.Png, 100);
+                        using var fs = File.OpenWrite(path);
+                        data.SaveTo(fs);
+                        sb.AppendLine("<div align=\"center\">");
+                        sb.AppendLine($"<img src=\"{name}\"/>");
+                        sb.AppendLine("</div>");
+                        if (captionMap.TryGetValue(region, out var cap))
+                        {
+                            sb.AppendLine($"<div align=\"center\">{WebUtility.HtmlEncode(cap)}</div>");
+                        }
+                        sb.AppendLine();
+                    }
+                    break;
+                case LayoutLabel.FigureTitle:
+                case LayoutLabel.TableTitle:
+                    if (region.TextBlocks != null && region.TextBlocks.Count > 0)
+                    {
+                        string caption = MergeText(region.TextBlocks);
+                        sb.AppendLine($"<div align=\"center\">{WebUtility.HtmlEncode(caption)}</div>");
+                        sb.AppendLine();
+                    }
+                    break;
+                default:
+                    if (region.TextBlocks != null && region.TextBlocks.Count > 0)
+                    {
+                        string text = MergeText(region.TextBlocks);
+                        if (region.Type == LayoutLabel.ParagraphTitle || region.Type == LayoutLabel.DocTitle)
+                            sb.Append('#').Append(' ').AppendLine(text);
+                        else
+                            sb.AppendLine(text);
+                        sb.AppendLine();
+                    }
+                    break;
+            }
+        }
+        return sb.ToString().TrimEnd();
+    }
+
+    private static string MergeText(IReadOnlyList<TextBlock> blocks)
+    {
+        var ordered = blocks
+            .OrderBy(b => b.BoxPoints.Min(p => p.Y))
+            .ThenBy(b => b.BoxPoints.Min(p => p.X))
+            .Select(b =>
+            {
+                var pts = b.BoxPoints;
+                float top = pts.Min(p => p.Y);
+                float bottom = pts.Max(p => p.Y);
+                float left = pts.Min(p => p.X);
+                float height = bottom - top;
+                return (Block: b, Top: top, Bottom: bottom, Left: left, Height: height);
+            }).ToList();
+
+        // Detect list markers
+        bool isBullet(string t) => t.TrimStart().StartsWith("- ") || t.TrimStart().StartsWith("* ") || t.TrimStart().StartsWith("• ");
+        bool isOrdered(string t) => Regex.IsMatch(t.TrimStart(), @"^\d+[\.\)]\s");
+
+        if (ordered.Any(o => isBullet(o.Block.GetText()) || isOrdered(o.Block.GetText())))
+        {
+            var items = new List<(int Level, bool Ordered, StringBuilder Content)>();
+            var startLines = ordered.Where(o => isBullet(o.Block.GetText()) || isOrdered(o.Block.GetText())).ToList();
+            float baseLeft = startLines.Min(l => l.Left);
+            float indentUnit = startLines.Select(l => l.Left - baseLeft).Where(d => d > 0).DefaultIfEmpty(startLines.First().Height).Min();
+
+            (int Level, bool Ordered, StringBuilder Content)? current = null;
+
+            foreach (var line in ordered)
+            {
+                string raw = line.Block.GetText();
+                bool start = isBullet(raw) || isOrdered(raw);
+                float offset = line.Left - baseLeft;
+                int level = indentUnit > 0 ? (int)System.Math.Round(offset / indentUnit) : 0;
+                bool orderedItem = isOrdered(raw);
+                string text = raw.TrimStart();
+                if (start)
+                {
+                    int idx = text.IndexOf(' ');
+                    if (idx >= 0)
+                        text = text[(idx + 1)..];
+                    current = (level, orderedItem, new StringBuilder(EscapeMarkdown(text)));
+                    items.Add(current.Value);
+                }
+                else if (current != null)
+                {
+                    current.Value.Content.Append(' ').Append(EscapeMarkdown(raw.Trim()));
+                }
+                else
+                {
+                    current = (level, false, new StringBuilder(EscapeMarkdown(raw.Trim())));
+                    items.Add(current.Value);
+                }
+            }
+
+            var counters = new Dictionary<int, int>();
+            var sbList = new StringBuilder();
+            foreach (var item in items)
+            {
+                if (item.Ordered)
+                    counters[item.Level] = counters.GetValueOrDefault(item.Level) + 1;
+                else
+                    counters[item.Level] = 0;
+                string prefix = item.Ordered ? $"{counters[item.Level]}. " : "- ";
+                sbList.Append(new string(' ', item.Level * 2)).Append(prefix).Append(item.Content).AppendLine();
+            }
+            return sbList.ToString().TrimEnd();
+        }
+
+        var paragraphs = new List<List<(TextBlock Block, float Top, float Bottom, float Left, float Height)>>();
+        List<(TextBlock Block, float Top, float Bottom, float Left, float Height)>? currentPara = null;
+        float prevBottom2 = 0;
+        float prevLeft2 = 0;
+        float prevHeight2 = 0;
+
+        foreach (var line in ordered)
+        {
+            bool newPara = currentPara == null;
+            if (!newPara)
+            {
+                float gap = line.Top - prevBottom2;
+                float threshold = System.Math.Max(prevHeight2, line.Height) * 0.8f;
+                float indent = System.Math.Abs(line.Left - prevLeft2);
+                if (gap > threshold || indent > threshold)
+                    newPara = true;
+            }
+
+            if (newPara)
+            {
+                currentPara = new List<(TextBlock, float, float, float, float)>();
+                paragraphs.Add(currentPara);
+            }
+
+            currentPara!.Add(line);
+            prevBottom2 = line.Bottom;
+            prevLeft2 = line.Left;
+            prevHeight2 = line.Height;
+        }
+
+        var sb = new StringBuilder();
+        foreach (var para in paragraphs)
+        {
+            if (sb.Length > 0)
+                sb.AppendLine().AppendLine();
+
+            var texts = para.Select(p => EscapeMarkdown(p.Block.GetText().Trim())).ToList();
+            string? prev = null;
+            foreach (var text in texts)
+            {
+                if (prev is null)
+                {
+                    sb.Append(text);
+                }
+                else if (prev.EndsWith('-') && text.Length > 0 && char.IsLetterOrDigit(text[0]))
+                {
+                    sb.Length -= 1; // remove hyphen
+                    sb.Append(text);
+                }
+                else if (text.Length > 0 && ",.;:!?".IndexOf(text[0]) >= 0)
+                {
+                    sb.Append(text);
+                }
+                else
+                {
+                    sb.Append(' ').Append(text);
+                }
+                prev = text;
+            }
+        }
+        return sb.ToString();
+    }
+
+    private static string EscapeMarkdown(string text)
+    {
+        var sb = new StringBuilder(text.Length);
+        foreach (var ch in text)
+        {
+            if (ch is '*' or '_' or '`' or '~' or '[' or ']' or '<' or '>' or '\\')
+                sb.Append('\\');
+            sb.Append(ch);
+        }
+        return sb.ToString();
+    }
+}

--- a/src/RapidStructureNet/StructureOptions.cs
+++ b/src/RapidStructureNet/StructureOptions.cs
@@ -1,0 +1,19 @@
+namespace RapidStructureNet;
+
+/// <summary>
+/// Options controlling the structure analysis pipeline.
+/// </summary>
+public sealed record StructureOptions
+{
+    /// <summary>
+    /// When true the pipeline will attempt to detect page orientation.
+    /// Currently this feature is not implemented and orientation will always be 0.
+    /// </summary>
+    public bool DetectOrientation { get; init; } = false;
+
+    /// <summary>
+    /// Minimum confidence required for a layout region to be kept.
+    /// </summary>
+    public float LayoutScoreThreshold { get; init; } = 0.5f;
+}
+

--- a/src/RapidStructureNet/StructureOptions.cs
+++ b/src/RapidStructureNet/StructureOptions.cs
@@ -6,8 +6,8 @@ namespace RapidStructureNet;
 public sealed record StructureOptions
 {
     /// <summary>
-    /// When true the pipeline will attempt to detect page orientation.
-    /// Currently this feature is not implemented and orientation will always be 0.
+    /// When true the pipeline attempts to detect page orientation and enables angle-aware OCR.
+    /// Without an <see cref="IOrientationDetector"/> the orientation angle will remain 0.
     /// </summary>
     public bool DetectOrientation { get; init; } = false;
 

--- a/src/RapidStructureNet/StructureRegion.cs
+++ b/src/RapidStructureNet/StructureRegion.cs
@@ -1,0 +1,57 @@
+using RapidLayoutNet;
+using RapidOcrNet;
+using RapidTableNet;
+using SkiaSharp;
+
+namespace RapidStructureNet;
+
+/// <summary>
+/// Represents a layout region detected on a page.
+/// </summary>
+public sealed class StructureRegion : IDisposable
+{
+    /// <summary>The region type coming from layout detection.</summary>
+    public LayoutLabel Type { get; }
+
+    /// <summary>Bounding box normalised to the range [0,1].</summary>
+    public SKRect BBox { get; }
+
+    /// <summary>Confidence score in [0,1].</summary>
+    public float Score { get; }
+
+    /// <summary>Page number starting at 0.</summary>
+    public int PageIndex { get; }
+
+    /// <summary>Cropped image of the region, when available.</summary>
+    public SKBitmap? Image { get; }
+
+    /// <summary>Detailed table result for table regions.</summary>
+    public TableResult? Table { get; }
+
+    /// <summary>OCR text blocks intersecting this region (only for non-table regions).</summary>
+    public IReadOnlyList<TextBlock>? TextBlocks { get; }
+
+    public StructureRegion(
+        LayoutLabel type,
+        SKRect bbox,
+        float score,
+        int pageIndex,
+        SKBitmap? image = null,
+        TableResult? table = null,
+        IReadOnlyList<TextBlock>? textBlocks = null)
+    {
+        Type = type;
+        BBox = bbox;
+        Score = score;
+        PageIndex = pageIndex;
+        Image = image;
+        Table = table;
+        TextBlocks = textBlocks;
+    }
+
+    public void Dispose()
+    {
+        Image?.Dispose();
+    }
+}
+

--- a/src/RapidStructureNet/StructureResult.cs
+++ b/src/RapidStructureNet/StructureResult.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using RapidOcrNet;
+
+namespace RapidStructureNet;
+
+/// <summary>
+/// Result of running the structure pipeline on a single page.
+/// </summary>
+/// <param name="Regions">Detected regions ordered by appearance.</param>
+/// <param name="Ocr">Full page OCR result.</param>
+/// <param name="Orientation">Rotation angle in degrees (0 when orientation detection is disabled).</param>
+public sealed record StructureResult(
+    IReadOnlyList<StructureRegion> Regions,
+    OcrResult Ocr,
+    float Orientation,
+    long LayoutTimeMs,
+    long OcrTimeMs,
+    long TableTimeMs);
+

--- a/src/RapidTableNet/TableRecognizer.cs
+++ b/src/RapidTableNet/TableRecognizer.cs
@@ -1,6 +1,7 @@
 using Microsoft.ML.OnnxRuntime;
 using Microsoft.ML.OnnxRuntime.Tensors;
 using SkiaSharp;
+using System.Diagnostics;
 
 namespace RapidTableNet;
 
@@ -24,7 +25,8 @@ public sealed class TableRecognizer : IDisposable
         {
             GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_EXTENDED,
             InterOpNumThreads = numThread,
-            IntraOpNumThreads = numThread
+            IntraOpNumThreads = numThread,
+            LogSeverityLevel = OrtLoggingLevel.ORT_LOGGING_LEVEL_ERROR
         };
 
         _session = new InferenceSession(path, options);
@@ -40,16 +42,26 @@ public sealed class TableRecognizer : IDisposable
             throw new InvalidOperationException("Model not initialised.");
         }
 
+        var sw = Stopwatch.StartNew();
         var (tensor, shape) = TablePreprocessor.Process(src);
+        long pre = sw.ElapsedMilliseconds;
+
+        sw.Restart();
         IReadOnlyCollection<NamedOnnxValue> inputs = new NamedOnnxValue[]
         {
             NamedOnnxValue.CreateFromTensor(_inputName, tensor)
         };
         using var results = _session.Run(inputs);
+        long infer = sw.ElapsedMilliseconds;
+
+        sw.Restart();
         var bboxPreds = results[0].AsTensor<float>();
         var structProbs = results[1].AsTensor<float>();
         var (structure, boxes) = _decoder.Decode(bboxPreds, structProbs, shape);
-        return new TableResult(structure, boxes);
+        string html = string.Concat(structure);
+        long decode = sw.ElapsedMilliseconds;
+
+        return new TableResult(structure, boxes, html, pre, infer, decode);
     }
 
     public void Dispose()

--- a/src/RapidTableNet/TableResult.cs
+++ b/src/RapidTableNet/TableResult.cs
@@ -1,3 +1,12 @@
 namespace RapidTableNet;
 
-public sealed record TableResult(IReadOnlyList<string> Structure, IReadOnlyList<float[]> CellBoxes);
+public sealed record TableResult(
+    IReadOnlyList<string> Structure,
+    IReadOnlyList<float[]> CellBoxes,
+    string Html,
+    long PreprocessTimeMs,
+    long InferenceTimeMs,
+    long DecodeTimeMs)
+{
+    public long TotalTimeMs => PreprocessTimeMs + InferenceTimeMs + DecodeTimeMs;
+}

--- a/tests/MarkItDownNet.Tests/MarkItDownNet.Tests.csproj
+++ b/tests/MarkItDownNet.Tests/MarkItDownNet.Tests.csproj
@@ -28,6 +28,8 @@
     <ProjectReference Include="..\..\src\MarkItDownNet\MarkItDownNet.csproj" />
     <ProjectReference Include="..\..\src\RapidLayoutNet\RapidLayoutNet.csproj" />
     <ProjectReference Include="..\..\src\RapidTableNet\RapidTableNet.csproj" />
+    <ProjectReference Include="..\..\src\RapidOcrNet\RapidOcrNet.csproj" />
+    <ProjectReference Include="..\..\src\RapidStructureNet\RapidStructureNet.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/MarkItDownNet.Tests/MarkdownBuilderTests.cs
+++ b/tests/MarkItDownNet.Tests/MarkdownBuilderTests.cs
@@ -1,0 +1,394 @@
+using System.IO;
+using System.Collections.Generic;
+using RapidLayoutNet;
+using RapidOcrNet;
+using RapidTableNet;
+using RapidStructureNet;
+using SkiaSharp;
+
+namespace MarkItDownNet.Tests;
+
+public class MarkdownBuilderTests
+{
+    [Fact]
+    public void Build_handles_text_table_image()
+    {
+        var block1 = new TextBlock
+        {
+            BoxPoints = new[] { new SKPointI(0, 0), new SKPointI(10, 0), new SKPointI(10, 10), new SKPointI(0, 10) },
+            BoxScore = 1,
+            AngleIndex = -1,
+            AngleScore = 0,
+            AngleTime = 0,
+            Chars = new[] { "Hello" },
+            CharScores = new[] { 1f },
+            CrnnTime = 0,
+            BlockTime = 0
+        };
+        var block2 = new TextBlock
+        {
+            BoxPoints = new[] { new SKPointI(0, 25), new SKPointI(10, 25), new SKPointI(10, 35), new SKPointI(0, 35) },
+            BoxScore = 1,
+            AngleIndex = -1,
+            AngleScore = 0,
+            AngleTime = 0,
+            Chars = new[] { "world" },
+            CharScores = new[] { 1f },
+            CrnnTime = 0,
+            BlockTime = 0
+        };
+        var textRegion = new StructureRegion(LayoutLabel.Text, new SKRect(0, 0, 1, 1), 1, 0, null, null, new List<TextBlock> { block1, block2 });
+
+        var tableHtml = "<table><thead><tr><td>a</td></tr></thead></table>";
+        var table = new TableResult(new[] { tableHtml }, Array.Empty<float[]>(), tableHtml, 0, 0, 0);
+        var tableRegion = new StructureRegion(LayoutLabel.Table, new SKRect(0, 0, 1, 1), 1, 0, null, table, null);
+
+        var img = new SKBitmap(1, 1);
+        using (var c = new SKCanvas(img)) c.Clear(SKColors.Black);
+        var imgRegion = new StructureRegion(LayoutLabel.Image, new SKRect(0, 0, 1, 1), 1, 0, img, null, null);
+
+        var result = new StructureResult(new[] { textRegion, tableRegion, imgRegion }, new OcrResult { TextBlocks = new[] { block1, block2 }, DbNetTime = 0, DetectTime = 0, StrRes = string.Empty }, 0, 0, 0, 0);
+
+        string dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        string md = StructureMarkdownBuilder.Build(result, dir);
+
+        Assert.Contains("Hello\n\nworld", md);
+        Assert.Contains(tableHtml, md);
+        Assert.Contains("<img src=\"figure_0.png\"/>", md);
+        Assert.True(File.Exists(Path.Combine(dir, "figure_0.png")));
+    }
+
+    [Fact]
+    public void Build_merges_lines_and_splits_paragraphs()
+    {
+        var block1 = new TextBlock
+        {
+            BoxPoints = new[] { new SKPointI(0, 0), new SKPointI(10, 0), new SKPointI(10, 10), new SKPointI(0, 10) },
+            BoxScore = 1,
+            AngleIndex = -1,
+            AngleScore = 0,
+            AngleTime = 0,
+            Chars = new[] { "Hello" },
+            CharScores = new[] { 1f },
+            CrnnTime = 0,
+            BlockTime = 0
+        };
+        var block2 = new TextBlock
+        {
+            BoxPoints = new[] { new SKPointI(0, 12), new SKPointI(10, 12), new SKPointI(10, 22), new SKPointI(0, 22) },
+            BoxScore = 1,
+            AngleIndex = -1,
+            AngleScore = 0,
+            AngleTime = 0,
+            Chars = new[] { "world" },
+            CharScores = new[] { 1f },
+            CrnnTime = 0,
+            BlockTime = 0
+        };
+        var block3 = new TextBlock
+        {
+            BoxPoints = new[] { new SKPointI(50, 50), new SKPointI(60, 50), new SKPointI(60, 60), new SKPointI(50, 60) },
+            BoxScore = 1,
+            AngleIndex = -1,
+            AngleScore = 0,
+            AngleTime = 0,
+            Chars = new[] { "Next" },
+            CharScores = new[] { 1f },
+            CrnnTime = 0,
+            BlockTime = 0
+        };
+
+        var region = new StructureRegion(LayoutLabel.Text, new SKRect(0, 0, 1, 1), 1, 0, null, null, new List<TextBlock> { block2, block3, block1 });
+        var result = new StructureResult(new[] { region }, new OcrResult { TextBlocks = new[] { block1, block2, block3 }, DbNetTime = 0, DetectTime = 0, StrRes = string.Empty }, 0, 0, 0, 0);
+
+        string md = StructureMarkdownBuilder.Build(result);
+
+        Assert.Equal("Hello world\n\nNext", md.Trim());
+    }
+
+    [Fact]
+    public void Build_sorts_regions_and_escapes_markdown()
+    {
+        var block1 = new TextBlock
+        {
+            BoxPoints = new[] { new SKPointI(0, 0), new SKPointI(10, 0), new SKPointI(10, 10), new SKPointI(0, 10) },
+            BoxScore = 1,
+            AngleIndex = -1,
+            AngleScore = 0,
+            AngleTime = 0,
+            Chars = new[] { "*top*" },
+            CharScores = new[] { 1f },
+            CrnnTime = 0,
+            BlockTime = 0
+        };
+        var block2 = new TextBlock
+        {
+            BoxPoints = new[] { new SKPointI(0, 50), new SKPointI(10, 50), new SKPointI(10, 60), new SKPointI(0, 60) },
+            BoxScore = 1,
+            AngleIndex = -1,
+            AngleScore = 0,
+            AngleTime = 0,
+            Chars = new[] { "bottom" },
+            CharScores = new[] { 1f },
+            CrnnTime = 0,
+            BlockTime = 0
+        };
+
+        var top = new StructureRegion(LayoutLabel.Text, new SKRect(0, 0, 1, 0.4f), 1, 0, null, null, new List<TextBlock> { block1 });
+        var bottom = new StructureRegion(LayoutLabel.Text, new SKRect(0, 0.5f, 1, 1), 1, 0, null, null, new List<TextBlock> { block2 });
+        // Provide regions out of order to ensure sorting
+        var result = new StructureResult(new[] { bottom, top }, new OcrResult { TextBlocks = new[] { block1, block2 }, DbNetTime = 0, DetectTime = 0, StrRes = string.Empty }, 0, 0, 0, 0);
+
+        string md = StructureMarkdownBuilder.Build(result);
+
+        Assert.StartsWith("\\*top\\*", md.Trim());
+        Assert.Contains("bottom", md);
+    }
+
+    [Fact]
+    public void Build_outputs_lists()
+    {
+        var item1 = new TextBlock
+        {
+            BoxPoints = new[] { new SKPointI(0, 0), new SKPointI(10, 0), new SKPointI(10, 10), new SKPointI(0, 10) },
+            BoxScore = 1,
+            AngleIndex = -1,
+            AngleScore = 0,
+            AngleTime = 0,
+            Chars = new[] { "- first" },
+            CharScores = new[] { 1f },
+            CrnnTime = 0,
+            BlockTime = 0
+        };
+        var item2 = new TextBlock
+        {
+            BoxPoints = new[] { new SKPointI(0, 20), new SKPointI(10, 20), new SKPointI(10, 30), new SKPointI(0, 30) },
+            BoxScore = 1,
+            AngleIndex = -1,
+            AngleScore = 0,
+            AngleTime = 0,
+            Chars = new[] { "- second" },
+            CharScores = new[] { 1f },
+            CrnnTime = 0,
+            BlockTime = 0
+        };
+        var region = new StructureRegion(LayoutLabel.Text, new SKRect(0, 0, 1, 1), 1, 0, null, null, new List<TextBlock> { item1, item2 });
+        var result = new StructureResult(new[] { region }, new OcrResult { TextBlocks = new[] { item1, item2 }, DbNetTime = 0, DetectTime = 0, StrRes = string.Empty }, 0, 0, 0, 0);
+
+        string md = StructureMarkdownBuilder.Build(result);
+        Assert.Equal("- first\n- second", md.Trim());
+    }
+
+    [Fact]
+    public void Build_outputs_ordered_lists()
+    {
+        var item1 = new TextBlock
+        {
+            BoxPoints = new[] { new SKPointI(0, 0), new SKPointI(10, 0), new SKPointI(10, 10), new SKPointI(0, 10) },
+            BoxScore = 1,
+            AngleIndex = -1,
+            AngleScore = 0,
+            AngleTime = 0,
+            Chars = new[] { "1. one" },
+            CharScores = new[] { 1f },
+            CrnnTime = 0,
+            BlockTime = 0
+        };
+        var item2 = new TextBlock
+        {
+            BoxPoints = new[] { new SKPointI(0, 20), new SKPointI(10, 20), new SKPointI(10, 30), new SKPointI(0, 30) },
+            BoxScore = 1,
+            AngleIndex = -1,
+            AngleScore = 0,
+            AngleTime = 0,
+            Chars = new[] { "2. two" },
+            CharScores = new[] { 1f },
+            CrnnTime = 0,
+            BlockTime = 0
+        };
+        var region = new StructureRegion(LayoutLabel.Text, new SKRect(0, 0, 1, 1), 1, 0, null, null, new List<TextBlock> { item1, item2 });
+        var result = new StructureResult(new[] { region }, new OcrResult { TextBlocks = new[] { item1, item2 }, DbNetTime = 0, DetectTime = 0, StrRes = string.Empty }, 0, 0, 0, 0);
+
+        string md = StructureMarkdownBuilder.Build(result);
+        Assert.Equal("1. one\n2. two", md.Trim());
+    }
+
+    [Fact]
+    public void Build_outputs_nested_lists()
+    {
+        var outer = new TextBlock
+        {
+            BoxPoints = new[] { new SKPointI(0, 0), new SKPointI(10, 0), new SKPointI(10, 10), new SKPointI(0, 10) },
+            BoxScore = 1,
+            AngleIndex = -1,
+            AngleScore = 0,
+            AngleTime = 0,
+            Chars = new[] { "- outer" },
+            CharScores = new[] { 1f },
+            CrnnTime = 0,
+            BlockTime = 0
+        };
+        var inner = new TextBlock
+        {
+            BoxPoints = new[] { new SKPointI(20, 20), new SKPointI(30, 20), new SKPointI(30, 30), new SKPointI(20, 30) },
+            BoxScore = 1,
+            AngleIndex = -1,
+            AngleScore = 0,
+            AngleTime = 0,
+            Chars = new[] { "- inner" },
+            CharScores = new[] { 1f },
+            CrnnTime = 0,
+            BlockTime = 0
+        };
+        var outer2 = new TextBlock
+        {
+            BoxPoints = new[] { new SKPointI(0, 40), new SKPointI(10, 40), new SKPointI(10, 50), new SKPointI(0, 50) },
+            BoxScore = 1,
+            AngleIndex = -1,
+            AngleScore = 0,
+            AngleTime = 0,
+            Chars = new[] { "- outer2" },
+            CharScores = new[] { 1f },
+            CrnnTime = 0,
+            BlockTime = 0
+        };
+        var region = new StructureRegion(LayoutLabel.Text, new SKRect(0, 0, 1, 1), 1, 0, null, null, new List<TextBlock> { outer, inner, outer2 });
+        var result = new StructureResult(new[] { region }, new OcrResult { TextBlocks = new[] { outer, inner, outer2 }, DbNetTime = 0, DetectTime = 0, StrRes = string.Empty }, 0, 0, 0, 0);
+
+        string md = StructureMarkdownBuilder.Build(result);
+        Assert.Equal("- outer\n  - inner\n- outer2", md.Trim());
+    }
+
+    [Fact]
+    public void Build_outputs_captions()
+    {
+        var cap = new TextBlock
+        {
+            BoxPoints = new[] { new SKPointI(0, 0), new SKPointI(10, 0), new SKPointI(10, 10), new SKPointI(0, 10) },
+            BoxScore = 1,
+            AngleIndex = -1,
+            AngleScore = 0,
+            AngleTime = 0,
+            Chars = new[] { "A figure caption" },
+            CharScores = new[] { 1f },
+            CrnnTime = 0,
+            BlockTime = 0
+        };
+        var region = new StructureRegion(LayoutLabel.FigureTitle, new SKRect(0, 0, 1, 1), 1, 0, null, null, new List<TextBlock> { cap });
+        var result = new StructureResult(new[] { region }, new OcrResult { TextBlocks = new[] { cap }, DbNetTime = 0, DetectTime = 0, StrRes = string.Empty }, 0, 0, 0, 0);
+
+        string md = StructureMarkdownBuilder.Build(result).Replace("\r", "");
+        Assert.Equal("<div align=\"center\">A figure caption</div>", md.Trim());
+    }
+
+    [Fact]
+    public void Build_associates_caption_with_image()
+    {
+        var cap = new TextBlock
+        {
+            BoxPoints = new[] { new SKPointI(0, 60), new SKPointI(10, 60), new SKPointI(10, 70), new SKPointI(0, 70) },
+            BoxScore = 1,
+            AngleIndex = -1,
+            AngleScore = 0,
+            AngleTime = 0,
+            Chars = new[] { "An image" },
+            CharScores = new[] { 1f },
+            CrnnTime = 0,
+            BlockTime = 0
+        };
+        var img = new SKBitmap(10, 10);
+        using (var c = new SKCanvas(img)) c.Clear(SKColors.Black);
+        var imgRegion = new StructureRegion(LayoutLabel.Image, new SKRect(0, 0, 1, 0.5f), 1, 0, img, null, null);
+        var capRegion = new StructureRegion(LayoutLabel.FigureTitle, new SKRect(0, 0.55f, 1, 0.7f), 1, 0, null, null, new List<TextBlock> { cap });
+        var result = new StructureResult(new[] { imgRegion, capRegion }, new OcrResult { TextBlocks = new[] { cap }, DbNetTime = 0, DetectTime = 0, StrRes = string.Empty }, 0, 0, 0, 0);
+
+        string dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        string md = StructureMarkdownBuilder.Build(result, dir).Replace("\r", "");
+        Assert.Contains("<div align=\"center\">\n<img src=\"figure_0.png\"/>\n</div>\n<div align=\"center\">An image</div>", md.Trim());
+    }
+
+    [Fact]
+    public void Build_associates_caption_before_image()
+    {
+        var cap = new TextBlock
+        {
+            BoxPoints = new[] { new SKPointI(0, 0), new SKPointI(10, 0), new SKPointI(10, 10), new SKPointI(0, 10) },
+            BoxScore = 1,
+            AngleIndex = -1,
+            AngleScore = 0,
+            AngleTime = 0,
+            Chars = new[] { "Before" },
+            CharScores = new[] { 1f },
+            CrnnTime = 0,
+            BlockTime = 0
+        };
+        var img = new SKBitmap(10, 10);
+        using (var c = new SKCanvas(img)) c.Clear(SKColors.Black);
+        var capRegion = new StructureRegion(LayoutLabel.FigureTitle, new SKRect(0, 0, 1, 0.1f), 1, 0, null, null, new List<TextBlock> { cap });
+        var imgRegion = new StructureRegion(LayoutLabel.Image, new SKRect(0, 0.2f, 1, 0.7f), 1, 0, img, null, null);
+        var result = new StructureResult(new[] { capRegion, imgRegion }, new OcrResult { TextBlocks = new[] { cap }, DbNetTime = 0, DetectTime = 0, StrRes = string.Empty }, 0, 0, 0, 0);
+
+        string dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        string md = StructureMarkdownBuilder.Build(result, dir).Replace("\r", "");
+        Assert.Equal("<div align=\"center\">\n<img src=\"figure_0.png\"/>\n</div>\n<div align=\"center\">Before</div>", md.Trim());
+    }
+
+    [Fact]
+    public void Build_associates_caption_with_table()
+    {
+        var cap = new TextBlock
+        {
+            BoxPoints = new[] { new SKPointI(0, 60), new SKPointI(10, 60), new SKPointI(10, 70), new SKPointI(0, 70) },
+            BoxScore = 1,
+            AngleIndex = -1,
+            AngleScore = 0,
+            AngleTime = 0,
+            Chars = new[] { "Table caption" },
+            CharScores = new[] { 1f },
+            CrnnTime = 0,
+            BlockTime = 0
+        };
+        var tableHtml = "<table><tbody><tr><td>x</td></tr></tbody></table>";
+        var table = new TableResult(new[] { tableHtml }, Array.Empty<float[]>(), tableHtml, 0, 0, 0);
+        var tableRegion = new StructureRegion(LayoutLabel.Table, new SKRect(0, 0, 1, 0.5f), 1, 0, null, table, null);
+        var capRegion = new StructureRegion(LayoutLabel.TableTitle, new SKRect(0, 0.55f, 1, 0.7f), 1, 0, null, null, new List<TextBlock> { cap });
+        var result = new StructureResult(new[] { tableRegion, capRegion }, new OcrResult { TextBlocks = new[] { cap }, DbNetTime = 0, DetectTime = 0, StrRes = string.Empty }, 0, 0, 0, 0);
+
+        string md = StructureMarkdownBuilder.Build(result).Replace("\r", "");
+        Assert.Contains("<table><tbody><tr><td>x</td></tr></tbody></table>\n<div align=\"center\">Table caption</div>", md);
+    }
+
+    [Fact]
+    public void MergeText_joins_hyphenated_lines()
+    {
+        var block1 = new TextBlock
+        {
+            BoxPoints = new[] { new SKPointI(0, 0), new SKPointI(10, 0), new SKPointI(10, 10), new SKPointI(0, 10) },
+            BoxScore = 1,
+            AngleIndex = -1,
+            AngleScore = 0,
+            AngleTime = 0,
+            Chars = new[] { "hyphen-" },
+            CharScores = new[] { 1f },
+            CrnnTime = 0,
+            BlockTime = 0
+        };
+        var block2 = new TextBlock
+        {
+            BoxPoints = new[] { new SKPointI(0, 12), new SKPointI(10, 12), new SKPointI(10, 22), new SKPointI(0, 22) },
+            BoxScore = 1,
+            AngleIndex = -1,
+            AngleScore = 0,
+            AngleTime = 0,
+            Chars = new[] { "ation" },
+            CharScores = new[] { 1f },
+            CrnnTime = 0,
+            BlockTime = 0
+        };
+        var region = new StructureRegion(LayoutLabel.Text, new SKRect(0, 0, 1, 1), 1, 0, null, null, new List<TextBlock> { block1, block2 });
+        var result = new StructureResult(new[] { region }, new OcrResult { TextBlocks = new[] { block1, block2 }, DbNetTime = 0, DetectTime = 0, StrRes = string.Empty }, 0, 0, 0, 0);
+
+        string md = StructureMarkdownBuilder.Build(result);
+        Assert.Contains("hyphenation", md);
+    }
+}

--- a/tests/MarkItDownNet.Tests/MarkdownBuilderTests.cs
+++ b/tests/MarkItDownNet.Tests/MarkdownBuilderTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Collections.Generic;
 using RapidLayoutNet;
@@ -356,6 +357,17 @@ public class MarkdownBuilderTests
 
         string md = StructureMarkdownBuilder.Build(result).Replace("\r", "");
         Assert.Contains("<table><tbody><tr><td>x</td></tr></tbody></table>\n<div align=\"center\">Table caption</div>", md);
+    }
+
+    [Fact]
+    public void Build_wraps_table_html_when_missing_tags()
+    {
+        var tableHtml = "<tr><td>1</td></tr>";
+        var table = new TableResult(new[] { tableHtml }, Array.Empty<float[]>(), tableHtml, 0, 0, 0);
+        var region = new StructureRegion(LayoutLabel.Table, new SKRect(0, 0, 1, 1), 1, 0, null, table, null);
+        var result = new StructureResult(new[] { region }, new OcrResult { TextBlocks = Array.Empty<TextBlock>(), DbNetTime = 0, DetectTime = 0, StrRes = string.Empty }, 0, 0, 0, 0);
+        string md = StructureMarkdownBuilder.Build(result).Replace("\r", "");
+        Assert.Equal("<table><tbody>\n<tr><td>1</td></tr>\n</tbody></table>", md.Trim());
     }
 
     [Fact]

--- a/tests/MarkItDownNet.Tests/RapidLayoutTests.cs
+++ b/tests/MarkItDownNet.Tests/RapidLayoutTests.cs
@@ -1,3 +1,4 @@
+using System;
 using RapidLayoutNet;
 using SkiaSharp;
 
@@ -7,6 +8,12 @@ public class RapidLayoutTests : IDisposable
 {
     private readonly LayoutDetector _detector;
     private static readonly string TrainingDir = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "dataset", "training"));
+
+    static RapidLayoutTests()
+    {
+        Environment.SetEnvironmentVariable("ORT_LOG_VERBOSITY_LEVEL", "0");
+        Environment.SetEnvironmentVariable("ORT_LOG_SEVERITY_LEVEL", "3");
+    }
 
     public RapidLayoutTests()
     {
@@ -62,5 +69,14 @@ public class RapidLayoutTests : IDisposable
         var boxes = _detector.Detect(bmp, 0.3f);
         Assert.Contains(boxes, b => b.Label == LayoutLabel.Table);
         Assert.Contains(boxes, b => b.Label == LayoutLabel.Text);
+    }
+
+    [Fact]
+    public void Returns_empty_with_high_threshold()
+    {
+        string path = Path.Combine(TrainingDir, "busta_paga_internet.jpeg");
+        using var bmp = SKBitmap.Decode(path);
+        var boxes = _detector.Detect(bmp, 1.1f);
+        Assert.Empty(boxes);
     }
 }

--- a/tests/MarkItDownNet.Tests/RapidStructureTests.cs
+++ b/tests/MarkItDownNet.Tests/RapidStructureTests.cs
@@ -95,6 +95,18 @@ public class RapidStructureTests : IDisposable
         return bmp;
     }
 
+    private sealed class FakeOrientationDetector : IOrientationDetector
+    {
+        public int Calls { get; private set; }
+        private readonly float _angle;
+        public FakeOrientationDetector(float angle) => _angle = angle;
+        public float Detect(SKBitmap image)
+        {
+            Calls++;
+            return _angle;
+        }
+    }
+
     [Theory]
     [MemberData(nameof(TrainingImages))]
     public void Analyze_returns_regions_with_normalised_boxes(string path)
@@ -152,6 +164,30 @@ public class RapidStructureTests : IDisposable
         long expectedTable = result.Regions.Where(r => r.Type == LayoutLabel.Table && r.Table != null)
                                            .Sum(r => r.Table!.TotalTimeMs);
         Assert.Equal(expectedTable, result.TableTimeMs);
+    }
+
+    [Fact]
+    public void Orientation_detector_not_called_when_disabled()
+    {
+        string path = Path.Combine(TrainingDir, "sample_invoice.png");
+        using var bmp = DecodeColor(path);
+        var fake = new FakeOrientationDetector(90);
+        var structure = new RapidStructure(_layout, new RapidOcrEngine(_ocr), _table, fake);
+        var result = structure.Analyze(bmp, new StructureOptions { DetectOrientation = false });
+        Assert.Equal(0f, result.Orientation);
+        Assert.Equal(0, fake.Calls);
+    }
+
+    [Fact]
+    public void Orientation_detector_called_when_enabled()
+    {
+        string path = Path.Combine(TrainingDir, "sample_invoice.png");
+        using var bmp = DecodeColor(path);
+        var fake = new FakeOrientationDetector(90);
+        var structure = new RapidStructure(_layout, new RapidOcrEngine(_ocr), _table, fake);
+        var result = structure.Analyze(bmp, new StructureOptions { DetectOrientation = true });
+        Assert.Equal(90f, result.Orientation);
+        Assert.Equal(1, fake.Calls);
     }
 
     [Fact]

--- a/tests/MarkItDownNet.Tests/RapidStructureTests.cs
+++ b/tests/MarkItDownNet.Tests/RapidStructureTests.cs
@@ -191,6 +191,41 @@ public class RapidStructureTests : IDisposable
     }
 
     [Fact]
+    public void Orientation_detector_rotates_boxes()
+    {
+        string path = Path.Combine(TrainingDir, "sample_invoice.png");
+        using var bmp = DecodeColor(path);
+        using var rot = Rotate90(bmp);
+
+        string clsModel = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "src", "RapidOcrNet", "models", "v2", "ch_ppocr_mobile_v2.0_cls_infer_opt.onnx"));
+        using var detector = new RapidOcrOrientationDetector(clsModel);
+        var structure = new RapidStructure(_layout, new RapidOcrEngine(_ocr), _table, detector);
+        var rotatedResult = structure.Analyze(rot, new StructureOptions { DetectOrientation = true });
+        Assert.Equal(270f, rotatedResult.Orientation);
+
+        Assert.NotEmpty(rotatedResult.Regions);
+        Assert.All(rotatedResult.Regions, r =>
+        {
+            Assert.InRange(r.BBox.Left, 0, 1);
+            Assert.InRange(r.BBox.Top, 0, 1);
+            Assert.InRange(r.BBox.Right, 0, 1);
+            Assert.InRange(r.BBox.Bottom, 0, 1);
+        });
+    }
+
+    private static SKBitmap Rotate90(SKBitmap src)
+    {
+        var dst = new SKBitmap(src.Height, src.Width);
+        using var canvas = new SKCanvas(dst);
+        canvas.Translate(dst.Width / 2f, dst.Height / 2f);
+        canvas.RotateDegrees(90);
+        canvas.Translate(-src.Width / 2f, -src.Height / 2f);
+        canvas.DrawBitmap(src, 0, 0);
+        canvas.Flush();
+        return dst;
+    }
+
+    [Fact]
     public void Fallbacks_to_table_when_layout_empty()
     {
         string path = Path.Combine(TrainingDir, "sample_invoice.png");
@@ -322,7 +357,7 @@ public class RapidStructureTests : IDisposable
         Assert.StartsWith(pythonSnippet[..len], oursSnippet);
     }
 
-    private static Process? _ppServer = StartPpstructureServer();
+    private static Process? _ppServer;
 
     private static Process? StartPpstructureServer()
     {
@@ -363,6 +398,8 @@ for line in sys.stdin:
 
     private static (List<string>? types, string? markdown) QueryPpstructure(string imagePath)
     {
+        if (Environment.GetEnvironmentVariable("ENABLE_PPSTRUCTURE") != "1")
+            return (null, null);
         try
         {
             if (_ppServer == null || _ppServer.HasExited)

--- a/tests/MarkItDownNet.Tests/RapidStructureTests.cs
+++ b/tests/MarkItDownNet.Tests/RapidStructureTests.cs
@@ -1,0 +1,368 @@
+using System;
+using System.Diagnostics;
+using System.Text.Json;
+using System.Linq;
+using System.Text.RegularExpressions;
+using RapidLayoutNet;
+using RapidOcrNet;
+using RapidStructureNet;
+using RapidTableNet;
+using SkiaSharp;
+
+namespace MarkItDownNet.Tests;
+
+public class RapidStructureTests : IDisposable
+{
+    private readonly LayoutDetector _layout;
+    private readonly TableRecognizer _table;
+    private readonly RapidOcr _ocr;
+    private readonly RapidStructure _structure;
+
+    private static readonly string TrainingDir = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "dataset", "training"));
+    private static readonly string ValidationDir = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "dataset", "validation"));
+
+    static RapidStructureTests()
+    {
+        Environment.SetEnvironmentVariable("ORT_LOG_VERBOSITY_LEVEL", "0");
+        Environment.SetEnvironmentVariable("ORT_LOG_SEVERITY_LEVEL", "3");
+    }
+
+    public RapidStructureTests()
+    {
+        string layoutModel = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "src", "RapidLayoutNet", "models", "PP-DocLayout-S_infer.onnx"));
+        _layout = new LayoutDetector();
+        _layout.InitModel(layoutModel);
+
+        string tableModelDir = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "src", "RapidTableNet", "models"));
+        _table = new TableRecognizer();
+        _table.InitModel(TableModel.SlanetPlus, tableModelDir);
+
+        _ocr = new RapidOcr();
+        _ocr.InitModels(OcrLanguage.English, OcrVersion.V5);
+        _structure = new RapidStructure(_layout, new RapidOcrEngine(_ocr), _table);
+    }
+
+    public void Dispose()
+    {
+        _layout.Dispose();
+        _table.Dispose();
+        _ocr.Dispose();
+    }
+
+    public static IEnumerable<object[]> TrainingImages()
+    {
+        foreach (var file in Directory.EnumerateFiles(TrainingDir))
+        {
+            var ext = Path.GetExtension(file).ToLowerInvariant();
+            if (ext is ".png" or ".jpg" or ".jpeg")
+                yield return new object[] { file };
+        }
+    }
+
+    public static IEnumerable<object[]> ValidationImages()
+    {
+        foreach (var dir in Directory.EnumerateDirectories(ValidationDir))
+        {
+            var name = Path.GetFileName(dir);
+            if (name.StartsWith("_"))
+                continue;
+            foreach (var file in Directory.EnumerateFiles(dir, "*.*", SearchOption.AllDirectories))
+            {
+                var ext = Path.GetExtension(file).ToLowerInvariant();
+                if (ext is ".png" or ".jpg" or ".jpeg")
+                    yield return new object[] { file };
+            }
+        }
+    }
+
+    public static IEnumerable<object[]> AllImages()
+    {
+        foreach (var img in TrainingImages())
+            yield return img;
+        foreach (var img in ValidationImages())
+            yield return img;
+    }
+
+    private static SKBitmap DecodeColor(string path)
+    {
+        var bmp = SKBitmap.Decode(path);
+        if (bmp.ColorType != SKColorType.Bgra8888)
+        {
+            var converted = bmp.Copy(SKColorType.Bgra8888);
+            bmp.Dispose();
+            return converted;
+        }
+        return bmp;
+    }
+
+    [Theory]
+    [MemberData(nameof(TrainingImages))]
+    public void Analyze_returns_regions_with_normalised_boxes(string path)
+    {
+        using var bmp = DecodeColor(path);
+        var result = _structure.Analyze(bmp);
+
+        Assert.NotEmpty(result.Regions);
+        Assert.Equal(0f, result.Orientation);
+        foreach (var r in result.Regions)
+        {
+            Assert.InRange(r.BBox.Left, 0, 1);
+            Assert.InRange(r.BBox.Top, 0, 1);
+            Assert.InRange(r.BBox.Right, 0, 1);
+            Assert.InRange(r.BBox.Bottom, 0, 1);
+            Assert.InRange(r.Score, 0f, 1f);
+            Assert.Equal(0, r.PageIndex);
+        }
+
+        Assert.All(result.Regions.Where(r => r.Type == LayoutLabel.Table), r =>
+        {
+            Assert.NotNull(r.Table);
+            Assert.False(string.IsNullOrWhiteSpace(r.Table!.Html));
+            Assert.NotEmpty(r.Table!.CellBoxes);
+            Assert.True(r.Table!.TotalTimeMs > 0);
+        });
+
+        Assert.NotEmpty(result.Ocr.TextBlocks);
+        Assert.All(result.Regions.Where(r => r.Type != LayoutLabel.Table && r.Type != LayoutLabel.Image), r =>
+        {
+            Assert.NotNull(r.TextBlocks);
+            Assert.NotEmpty(r.TextBlocks!);
+            foreach (var block in r.TextBlocks!)
+            {
+                var pts = block.BoxPoints;
+                float minX = pts.Min(p => p.X);
+                float minY = pts.Min(p => p.Y);
+                float maxX = pts.Max(p => p.X);
+                float maxY = pts.Max(p => p.Y);
+                var textRect = new SKRect(minX, minY, maxX, maxY);
+                var regionRect = new SKRect(r.BBox.Left * bmp.Width, r.BBox.Top * bmp.Height,
+                                            r.BBox.Right * bmp.Width, r.BBox.Bottom * bmp.Height);
+                Assert.True(regionRect.IntersectsWith(textRect));
+            }
+        });
+
+        var regionBlocks = result.Regions.Where(r => r.Type != LayoutLabel.Table && r.Type != LayoutLabel.Image)
+                                         .SelectMany(r => r.TextBlocks!)
+                                         .ToList();
+        Assert.Equal(regionBlocks.Count, regionBlocks.Distinct().Count());
+        Assert.True(regionBlocks.Count <= result.Ocr.TextBlocks.Length);
+
+        Assert.True(result.LayoutTimeMs > 0);
+        Assert.True(result.OcrTimeMs > 0);
+        long expectedTable = result.Regions.Where(r => r.Type == LayoutLabel.Table && r.Table != null)
+                                           .Sum(r => r.Table!.TotalTimeMs);
+        Assert.Equal(expectedTable, result.TableTimeMs);
+    }
+
+    [Fact]
+    public void Fallbacks_to_table_when_layout_empty()
+    {
+        string path = Path.Combine(TrainingDir, "sample_invoice.png");
+        using var bmp = DecodeColor(path);
+        var options = new StructureOptions { LayoutScoreThreshold = 1.1f };
+        var result = _structure.Analyze(bmp, options);
+        var region = Assert.Single(result.Regions);
+        Assert.Equal(LayoutLabel.Table, region.Type);
+    }
+
+    [Theory]
+    [MemberData(nameof(AllImages))]
+    public void Markdown_contains_tables_and_images_when_present(string path)
+    {
+        using var bmp = DecodeColor(path);
+        var result = _structure.Analyze(bmp);
+        string dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        string md = StructureMarkdownBuilder.Build(result, dir);
+
+        Assert.False(string.IsNullOrWhiteSpace(md));
+        if (result.Regions.Any(r => r.Type == LayoutLabel.Table))
+        {
+            Assert.Contains("<table", md);
+            Assert.All(result.Regions.Where(r => r.Type == LayoutLabel.Table), r =>
+            {
+                Assert.False(string.IsNullOrWhiteSpace(r.Table!.Html));
+            });
+        }
+        if (result.Regions.Any(r => r.Type == LayoutLabel.Image))
+        {
+            Assert.Contains("<img", md);
+            var files = Directory.Exists(dir) ? Directory.GetFiles(dir, "figure_*.png") : Array.Empty<string>();
+            Assert.Equal(result.Regions.Count(r => r.Type == LayoutLabel.Image), files.Length);
+            foreach (var f in files)
+                Assert.Contains(Path.GetFileName(f), md);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(AllImages))]
+    public void Table_html_cell_count_matches_boxes(string path)
+    {
+        using var bmp = DecodeColor(path);
+        var result = _structure.Analyze(bmp);
+        foreach (var table in result.Regions.Where(r => r.Type == LayoutLabel.Table))
+        {
+            int tdCount = Regex.Matches(table.Table!.Html, "<td", RegexOptions.IgnoreCase).Count;
+            Assert.Equal(tdCount, table.Table!.CellBoxes.Count);
+        }
+    }
+
+    [SkippableTheory]
+    [MemberData(nameof(TrainingImages))]
+    public void Pipeline_detects_table_like_ppstructure(string path)
+    {
+        using var bmp = DecodeColor(path);
+        var result = _structure.Analyze(bmp);
+
+        var pythonTypes = RunPpstructure(path);
+        Skip.If(pythonTypes is null || pythonTypes.Count == 0, "ppstructure not available");
+
+        bool pythonHasTable = pythonTypes.Contains("table");
+        if (pythonHasTable)
+            Assert.Contains(result.Regions, r => r.Type == LayoutLabel.Table);
+    }
+
+    [SkippableTheory]
+    [MemberData(nameof(TrainingImages))]
+    public void Markdown_is_reasonably_close_to_ppstructure(string path)
+    {
+        using var bmp = DecodeColor(path);
+        var result = _structure.Analyze(bmp);
+        string ours = StructureMarkdownBuilder.Build(result);
+
+        var pythonMd = RunPpstructureMarkdown(path);
+        Skip.If(pythonMd is null, "ppstructure not available");
+
+        Assert.False(string.IsNullOrWhiteSpace(ours));
+        Assert.False(string.IsNullOrWhiteSpace(pythonMd));
+
+        if (pythonMd.Contains("<table"))
+            Assert.Contains("<table", ours);
+        if (pythonMd.Contains("![") || pythonMd.Contains("<img"))
+            Assert.Contains("<img", ours);
+
+        string oursSnippet = ours.ReplaceLineEndings("\n").Trim();
+        string pythonSnippet = pythonMd.ReplaceLineEndings("\n").Trim();
+        int len = Math.Min(80, Math.Min(oursSnippet.Length, pythonSnippet.Length));
+        Assert.Contains(pythonSnippet[..len], oursSnippet);
+    }
+
+    [SkippableTheory]
+    [MemberData(nameof(ValidationImages))]
+    public void Pipeline_detects_table_like_ppstructure_validation(string path)
+    {
+        using var bmp = DecodeColor(path);
+        var result = _structure.Analyze(bmp);
+
+        var pythonTypes = RunPpstructure(path);
+        Skip.If(pythonTypes is null || pythonTypes.Count == 0, "ppstructure not available");
+
+        bool pythonHasTable = pythonTypes.Contains("table");
+        if (pythonHasTable)
+            Assert.Contains(result.Regions, r => r.Type == LayoutLabel.Table);
+    }
+
+    [SkippableTheory]
+    [MemberData(nameof(ValidationImages))]
+    public void Markdown_is_reasonably_close_to_ppstructure_validation(string path)
+    {
+        using var bmp = DecodeColor(path);
+        var result = _structure.Analyze(bmp);
+        string ours = StructureMarkdownBuilder.Build(result);
+
+        var pythonMd = RunPpstructureMarkdown(path);
+        Skip.If(pythonMd is null, "ppstructure not available");
+
+        Assert.False(string.IsNullOrWhiteSpace(ours));
+        Assert.False(string.IsNullOrWhiteSpace(pythonMd));
+
+        if (pythonMd.Contains("<table"))
+            Assert.Contains("<table", ours);
+        if (pythonMd.Contains("![") || pythonMd.Contains("<img"))
+            Assert.Contains("<img", ours);
+
+        string oursSnippet = ours.ReplaceLineEndings("\n").Trim();
+        string pythonSnippet = pythonMd.ReplaceLineEndings("\n").Trim();
+        int len = Math.Min(120, Math.Min(oursSnippet.Length, pythonSnippet.Length));
+        Assert.StartsWith(pythonSnippet[..len], oursSnippet);
+    }
+
+    private static Process? _ppServer = StartPpstructureServer();
+
+    private static Process? StartPpstructureServer()
+    {
+        string script = """
+import json,sys,os,tempfile,subprocess
+repo='/tmp/PaddleOCR'
+if not os.path.exists(repo):
+    subprocess.run(['git','clone','--depth','1','https://github.com/PaddlePaddle/PaddleOCR',repo], check=True)
+sys.path.insert(0, repo)
+from paddleocr import PPStructureV3
+pipeline=PPStructureV3(lang='en', use_chart_recognition=False, use_formula_recognition=False)
+for line in sys.stdin:
+    path=line.strip()
+    if not path:
+        continue
+    if path=='__quit__':
+        break
+    res=pipeline.predict(path)
+    types=[box['label'] for box in res[0]['layout_det_res']['boxes']]
+    tmp=tempfile.mkdtemp()
+    res[0].save_to_markdown(tmp)
+    md_path=os.path.join(tmp, os.path.splitext(os.path.basename(path))[0] + '.md')
+    with open(md_path,'r',encoding='utf-8') as f:
+        md=f.read()
+    print(json.dumps({'types':types,'markdown':md}), flush=True)
+""";
+
+        string tmp = Path.GetTempFileName() + ".py";
+        File.WriteAllText(tmp, script);
+        var psi = new ProcessStartInfo("python", $"\"{tmp}\"")
+        {
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+        return Process.Start(psi);
+    }
+
+    private static (List<string>? types, string? markdown) QueryPpstructure(string imagePath)
+    {
+        try
+        {
+            if (_ppServer == null || _ppServer.HasExited)
+                _ppServer = StartPpstructureServer();
+            var p = _ppServer;
+            if (p == null) return (null, null);
+            lock (p)
+            {
+                p.StandardInput.WriteLine(imagePath);
+                p.StandardInput.Flush();
+                string? line = p.StandardOutput.ReadLine();
+                if (string.IsNullOrWhiteSpace(line)) return (null, null);
+                var doc = JsonDocument.Parse(line);
+                var types = new List<string>();
+                foreach (var el in doc.RootElement.GetProperty("types").EnumerateArray())
+                    types.Add(el.GetString()!);
+                string markdown = doc.RootElement.GetProperty("markdown").GetString()!;
+                return (types, markdown);
+            }
+        }
+        catch
+        {
+            return (null, null);
+        }
+    }
+
+    private static List<string>? RunPpstructure(string imagePath)
+    {
+        var (types, _) = QueryPpstructure(imagePath);
+        return types;
+    }
+
+    private static string? RunPpstructureMarkdown(string imagePath)
+    {
+        var (_, md) = QueryPpstructure(imagePath);
+        return md;
+    }
+}
+

--- a/tests/MarkItDownNet.Tests/RapidTableTests.cs
+++ b/tests/MarkItDownNet.Tests/RapidTableTests.cs
@@ -1,3 +1,4 @@
+using System;
 using RapidLayoutNet;
 using RapidTableNet;
 using SkiaSharp;
@@ -9,6 +10,12 @@ public class RapidTableTests : IDisposable
     private readonly LayoutDetector _layout;
     private readonly TableRecognizer _table;
     private static readonly string TrainingDir = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "dataset", "training"));
+
+    static RapidTableTests()
+    {
+        Environment.SetEnvironmentVariable("ORT_LOG_VERBOSITY_LEVEL", "0");
+        Environment.SetEnvironmentVariable("ORT_LOG_SEVERITY_LEVEL", "3");
+    }
 
     public RapidTableTests()
     {
@@ -41,6 +48,11 @@ public class RapidTableTests : IDisposable
         var result = _table.Detect(tableBmp);
         Assert.NotEmpty(result.Structure);
         Assert.NotEmpty(result.CellBoxes);
+        Assert.False(string.IsNullOrWhiteSpace(result.Html));
+        Assert.True(result.PreprocessTimeMs >= 0);
+        Assert.True(result.InferenceTimeMs > 0);
+        Assert.True(result.DecodeTimeMs > 0);
+        Assert.Equal(result.PreprocessTimeMs + result.InferenceTimeMs + result.DecodeTimeMs, result.TotalTimeMs);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Document PPStructureV3 markdown extraction using `save_to_markdown` and remove prior recovery module references
- Update Python comparison helper to call `PPStructureV3.save_to_markdown` for Markdown output
- Reuse a single lightweight `PPStructureV3` instance in parity tests and tighten markdown snippet comparisons

## Testing
- `dotnet test -l "console;verbosity=minimal"` *(fails: build canceled after lengthy PPStructure runs)*
- `python - <<'PY'
import cv2
from paddleocr import PPStructureV3
engine=PPStructureV3(lang='en', use_chart_recognition=False, use_formula_recognition=False)
img=cv2.imread('dataset/training/sample_invoice.png')
res=engine.predict(img)
print([box['label'] for box in res[0]['layout_det_res']['boxes']])
PY`


------
https://chatgpt.com/codex/tasks/task_e_68aea33c69a48325a903767fcb056dcf